### PR TITLE
Ensure that Random classes successfully produce the requested bytes

### DIFF
--- a/Sources/BCrypt/BCrypt.swift
+++ b/Sources/BCrypt/BCrypt.swift
@@ -600,10 +600,19 @@ public struct BCryptSalt {
      Creates a new random salt with the specified cost factor. Default cost factor of 10, which is probably
      ~100 ms to hash a password on a modern CPU.
      */
+    @available(*, deprecated, message: "Use `init(costFactor: Int) throws` instead.")
     public init(cost: Int = 10) {
+        try! self.init(costFactor: cost)
+    }
+
+    /**
+    Creates a new random salt with the specified cost factor. Default cost factor of 10, which is probably
+    ~100 ms to hash a password on a modern CPU.
+    */
+    public init(costFactor: Int = 10) throws {
         self.scheme = "2a"
-        self.cost = cost
-        self.data = BCrypt.random.bytes(16)
+        self.cost = costFactor
+        self.data = try BCrypt.random.bytes(count: 16)
     }
 }
 

--- a/Sources/Hash/Random.swift
+++ b/Sources/Hash/Random.swift
@@ -12,7 +12,7 @@ extension Hash {
     }
 
     public static func random<R: Random>(_ m: Method, _ r: R) throws -> Bytes {
-        let message = r.bytes(64)
+        let message = try r.bytes(count: 64)
         return try Hash.make(m, message)
     }
 }

--- a/Sources/Random/CryptoRandom.swift
+++ b/Sources/Random/CryptoRandom.swift
@@ -1,30 +1,75 @@
 import CLibreSSL
 import Core
 
+
+/// Represents an error returned by a LibreSSL function
+public class LibreSSLError: Swift.Error, CustomStringConvertible {
+    public let errorCode: UInt
+    public let functionName: String?
+
+    public init(errorCode: UInt? = nil, functionName: String? = nil) {
+        self.errorCode = errorCode ?? ERR_get_error()
+        self.functionName = functionName
+    }
+
+    public var description: String {
+        var errorMessage = "Error \(errorCode)"
+
+        // If we know the failing function's name, add it
+        if let fn = functionName {
+            errorMessage += " in \(fn)"
+        }
+
+        // Try to get a nice error message from LibreSSL
+        if let errorCStr = ERR_error_string(errorCode, nil) {
+            let errorStr = String(cString: UnsafePointer<CChar>(errorCStr))
+            errorMessage += ": \(errorStr)"
+        }
+        return errorMessage
+    }
+}
+
+
+/// Generates cryptographically secure random data using LibreSSL
 public final class CryptoRandom: Random {
     public init() {}
 
-    public func bytes(_ num: Int) -> Bytes {
-        var random = Bytes(repeating: 0, count: num)
-		guard RAND_bytes(&random, Int32(num)) == 1 else {
-			// If the requested number of random bytes couldn't be read,
-			// we need to fail fast and hard.
-			abort()
-		}
+    public func bytes(count: Int) throws -> Bytes {
+        var random = Bytes(repeating: 0, count: count)
+        guard RAND_bytes(&random, Int32(count)) == 1 else {
+            // If the requested number of random bytes couldn't be read,
+            // we need to throw an error
+            throw LibreSSLError(functionName: "RAND_bytes")
+        }
         return random
     }
 }
 
-public final class PsuedoRandom: Random {
+
+/// Generates non-secure pseudorandom data using LibreSSL
+public final class PseudoRandom: Random {
     public init() {}
 
-    public func bytes(_ num: Int) -> Bytes {
-        var random = Bytes(repeating: 0, count: num)
-		guard RAND_pseudo_bytes(&random, Int32(num)) == 1 else {
-			// If the requested number of random bytes couldn't be read,
-			// we need to fail fast and hard.
-			abort()
-		}
+    public func bytes(count: Int) throws -> Bytes {
+        var random = Bytes(repeating: 0, count: count)
+        guard RAND_pseudo_bytes(&random, Int32(count)) == 1 else {
+            // If the requested number of random bytes couldn't be read,
+            // we need to throw an error
+            throw LibreSSLError(functionName: "RAND_pseudo_bytes")
+        }
         return random
+    }
+}
+
+
+// Class name has typo ('e' and 'u' reversed)
+@available(*, deprecated, renamed: "PseudoRandom")
+public final class PsuedoRandom: Random {
+    let prng = PseudoRandom()
+
+    public init() {}
+
+    public func bytes(count: Int) throws -> Bytes {
+        return try prng.bytes(count: count)
     }
 }

--- a/Sources/Random/CryptoRandom.swift
+++ b/Sources/Random/CryptoRandom.swift
@@ -6,7 +6,11 @@ public final class CryptoRandom: Random {
 
     public func bytes(_ num: Int) -> Bytes {
         var random = Bytes(repeating: 0, count: num)
-        RAND_bytes(&random, Int32(num))
+		guard RAND_bytes(&random, Int32(num)) == 1 else {
+			// If the requested number of random bytes couldn't be read,
+			// we need to fail fast and hard.
+			abort()
+		}
         return random
     }
 }
@@ -16,7 +20,11 @@ public final class PsuedoRandom: Random {
 
     public func bytes(_ num: Int) -> Bytes {
         var random = Bytes(repeating: 0, count: num)
-        RAND_pseudo_bytes(&random, Int32(num))
+		guard RAND_pseudo_bytes(&random, Int32(num)) == 1 else {
+			// If the requested number of random bytes couldn't be read,
+			// we need to fail fast and hard.
+			abort()
+		}
         return random
     }
 }

--- a/Sources/Random/Random+Deprecated.swift
+++ b/Sources/Random/Random+Deprecated.swift
@@ -1,0 +1,132 @@
+import Core
+
+// MARK: Deprecated non-throwing properties
+extension Random {
+    /// Get a random Int8
+    @available(*, deprecated, message: "Use the throwing method instead.")
+    public var int8: Int8 {
+        return try! randInt8()
+    }
+
+    /// Get a random UInt8
+    @available(*, deprecated, message: "Use the throwing method instead.")
+    public var uint8: UInt8 {
+        return try! randUInt8()
+    }
+
+    /// Get a random Int16
+    @available(*, deprecated, message: "Use the throwing method instead.")
+    public var int16: Int16 {
+        return try! randInt16()
+    }
+
+    /// Get a random UInt16
+    @available(*, deprecated, message: "Use the throwing method instead.")
+    public var uint16: UInt16 {
+        return try! randUInt16()
+    }
+
+    /// Get a random Int32
+    @available(*, deprecated, message: "Use the throwing method instead.")
+    public var int32: Int32 {
+        return try! randInt32()
+    }
+
+    /// Get a random UInt32
+    @available(*, deprecated, message: "Use the throwing method instead.")
+    public var uint32: UInt32 {
+        return try! randUInt32()
+    }
+
+    /// Get a random Int64
+    @available(*, deprecated, message: "Use the throwing method instead.")
+    public var int64: Int64 {
+        return try! randInt64()
+    }
+
+    /// Get a random UInt64
+    @available(*, deprecated, message: "Use the throwing method instead.")
+    public var uint64: UInt64 {
+        return try! randUInt64()
+    }
+
+    /// Get a random Int
+    @available(*, deprecated, message: "Use the throwing method instead.")
+    public var int: Int {
+        return try! randInt()
+    }
+
+    /// Get a random UInt
+    @available(*, deprecated, message: "Use the throwing method instead.")
+    public var uint: UInt {
+        return try! randUInt()
+    }
+}
+
+// MARK: - Deprecated static non-throwing methods/properties
+extension Random {
+    @available(*, deprecated, message: "Use the throwing method instead.")
+    public static func bytes(_ num: Int) -> Bytes {
+        return try! bytes(count: num)
+    }
+
+    /// Get a random Int8
+    @available(*, deprecated, message: "Use the throwing method instead.")
+    public static var int8: Int8 {
+        return try! randInt8()
+    }
+
+    /// Get a random UInt8
+    @available(*, deprecated, message: "Use the throwing method instead.")
+    public static var uint8: UInt8 {
+        return try! randUInt8()
+    }
+
+    /// Get a random Int16
+    @available(*, deprecated, message: "Use the throwing method instead.")
+    public static var int16: Int16 {
+        return try! randInt16()
+    }
+
+    /// Get a random UInt16
+    @available(*, deprecated, message: "Use the throwing method instead.")
+    public static var uint16: UInt16 {
+        return try! randUInt16()
+    }
+
+    /// Get a random Int32
+    @available(*, deprecated, message: "Use the throwing method instead.")
+    public static var int32: Int32 {
+        return try! randInt32()
+    }
+
+    /// Get a random UInt32
+    @available(*, deprecated, message: "Use the throwing method instead.")
+    public static var uint32: UInt32 {
+        return try! randUInt32()
+    }
+
+    /// Get a random Int64
+    @available(*, deprecated, message: "Use the throwing method instead.")
+    public static var int64: Int64 {
+        return try! randInt64()
+    }
+
+    /// Get a random UInt64
+    @available(*, deprecated, message: "Use the throwing method instead.")
+    public static var uint64: UInt64 {
+        return try! randUInt64()
+    }
+
+    /// Get a random Int
+    @available(*, deprecated, message: "Use the throwing method instead.")
+    public static var int: Int {
+        return try! randInt()
+    }
+
+    /// Get a random UInt
+    @available(*, deprecated, message: "Use the throwing method instead.")
+    public static var uint: UInt {
+        return try! randUInt()
+    }
+}

--- a/Sources/Random/Random.swift
+++ b/Sources/Random/Random.swift
@@ -3,9 +3,6 @@ import Core
 public protocol Random {
     init()
 
-    @available(*, deprecated, message: "Use the throwing method instead.")
-    func bytes(_ num: Int) -> Bytes
-
     /// Get a random array of Bytes
     func bytes(count: Int) throws -> Bytes
 }
@@ -13,6 +10,7 @@ public protocol Random {
 
 // MARK: - Deprecated non-throwing bytes method
 extension Random {
+    @available(*, deprecated, message: "Use the throwing method instead.")
     public func bytes(_ num: Int) -> Bytes {
         return try! bytes(count: num)
     }

--- a/Sources/Random/Random.swift
+++ b/Sources/Random/Random.swift
@@ -2,127 +2,142 @@ import Core
 
 public protocol Random {
     init()
+
+    @available(*, deprecated, message: "Use the throwing method instead.")
     func bytes(_ num: Int) -> Bytes
+
+    /// Get a random array of Bytes
+    func bytes(count: Int) throws -> Bytes
 }
 
+
+// MARK: - Deprecated non-throwing bytes method
 extension Random {
-    /// Get a random int8
-    public var int8: Int8 {
-        return Int8(bitPattern: uint8)
-    }
-
-    /// Get a random uint8
-    public var uint8: UInt8 {
-        return bytes(1)[0]
-    }
-
-    /// Get a random int16
-    public var int16: Int16 {
-        let random = bytes(2)
-        return UnsafeMutableRawPointer(mutating: random)
-            .assumingMemoryBound(to: Int16.self)
-            .pointee
-    }
-
-    /// Get a random uint16
-    public var uint16: UInt16 {
-        return UInt16(bitPattern: int16)
-    }
-
-    /// Get a random int32
-    public var int32: Int32 {
-        let random = bytes(4)
-        return UnsafeMutableRawPointer(mutating: random)
-            .assumingMemoryBound(to: Int32.self)
-            .pointee
-    }
-
-    /// Get a random uint32
-    public var uint32: UInt32 {
-        return UInt32(bitPattern: int32)
-    }
-
-    /// Get a random int64
-    public var int64: Int64 {
-        let random = bytes(8)
-        return UnsafeMutableRawPointer(mutating: random)
-            .assumingMemoryBound(to: Int64.self)
-            .pointee
-    }
-
-    /// Get a random uint64
-    public var uint64: UInt64 {
-        return UInt64(bitPattern: int64)
-    }
-
-    /// Get a random int
-    public var int: Int {
-        let random = bytes(MemoryLayout<Int>.size)
-        return UnsafeMutableRawPointer(mutating: random)
-            .assumingMemoryBound(to: Int.self)
-            .pointee
-    }
-
-    /// Get a random uint
-    public var uint: UInt {
-        return UInt(bitPattern: int)
+    public func bytes(_ num: Int) -> Bytes {
+        return try! bytes(count: num)
     }
 }
 
-// MARK: Static
 
+// MARK: - Throwing getter methods
 extension Random {
-    /// Get a random int8
-    public static var int8: Int8 {
-        return Self().int8
+    /// Get a random Int8
+    public func randInt8() throws -> Int8 {
+        return Int8(bitPattern: try randUInt8())
     }
 
-    /// Get a random uint8
-    public static var uint8: UInt8 {
-        return Self().uint8
+    /// Get a random UInt8
+    public func randUInt8() throws -> UInt8 {
+        return try bytes(count: 1)[0]
     }
 
-    /// Get a random int16
-    public static var int16: Int16 {
-        return Self().int16
+    /// Get a random Int16
+    public func randInt16() throws -> Int16 {
+        return Int16(bitPattern: try randUInt16())
     }
 
-    /// Get a random uint16
-    public static var uint16: UInt16 {
-        return Self().uint16
+    /// Get a random UInt16
+    public func randUInt16() throws -> UInt16 {
+        let random = try bytes(count: 2)
+        return UnsafeRawPointer(random)
+            .assumingMemoryBound(to: UInt16.self)
+            .pointee
     }
 
-    /// Get a random int32
-    public static var int32: Int32 {
-        return Self().int32
+    /// Get a random Int32
+    public func randInt32() throws -> Int32 {
+        return Int32(bitPattern: try randUInt32())
     }
 
-    /// Get a random uint32
-    public static var uint32: UInt32 {
-        return Self().uint32
+    /// Get a random UInt32
+    public func randUInt32() throws -> UInt32 {
+        let random = try bytes(count: 4)
+        return UnsafeRawPointer(random)
+            .assumingMemoryBound(to: UInt32.self)
+            .pointee
     }
 
-    /// Get a random int64
-    public static var int64: Int64 {
-        return Self().int64
+    /// Get a random Int64
+    public func randInt64() throws -> Int64 {
+        return Int64(bitPattern: try randUInt64())
     }
 
-    /// Get a random uint64
-    public static var uint64: UInt64 {
-        return Self().uint64
+    /// Get a random UInt64
+    public func randUInt64() throws -> UInt64 {
+        let random = try bytes(count: 8)
+        return UnsafeRawPointer(random)
+            .assumingMemoryBound(to: UInt64.self)
+            .pointee
     }
 
-    /// Get a random int
-    public static var int: Int {
-        return Self().int
+    /// Get a random Int
+    public func randInt() throws -> Int {
+        return Int(bitPattern: try randUInt())
     }
 
-    /// Get a random uint
-    public static var uint: UInt {
-        return Self().uint
+    /// Get a random UInt
+    public func randUInt() throws -> UInt {
+        let random = try bytes(count: MemoryLayout<UInt>.size)
+        return UnsafeRawPointer(random)
+            .assumingMemoryBound(to: UInt.self)
+            .pointee
+    }
+}
+
+
+// MARK: - Throwing static methods
+extension Random {
+    public static func bytes(count: Int) throws -> Bytes {
+        return try Self().bytes(count: count)
     }
 
-    public static func bytes(_ num: Int) -> Bytes {
-        return Self().bytes(num)
+    /// Get a random Int8
+    public static func randInt8() throws -> Int8 {
+        return try Self().randInt8()
+    }
+
+    /// Get a random UInt8
+    public static func randUInt8() throws -> UInt8 {
+        return try Self().randUInt8()
+    }
+
+    /// Get a random Int16
+    public static func randInt16() throws -> Int16 {
+        return try Self().randInt16()
+    }
+
+    /// Get a random UInt16
+    public static func randUInt16() throws -> UInt16 {
+        return try Self().randUInt16()
+    }
+
+    /// Get a random Int32
+    public static func randInt32() throws -> Int32 {
+        return try Self().randInt32()
+    }
+
+    /// Get a random UInt32
+    public static func randUInt32() throws -> UInt32 {
+        return try Self().randUInt32()
+    }
+
+    /// Get a random Int64
+    public static func randInt64() throws -> Int64 {
+        return try Self().randInt64()
+    }
+
+    /// Get a random UInt64
+    public static func randUInt64() throws -> UInt64 {
+        return try Self().randUInt64()
+    }
+
+    /// Get a random Int
+    public static func randInt() throws -> Int {
+        return try Self().randInt()
+    }
+
+    /// Get a random UInt
+    public static func randUInt() throws -> UInt {
+        return try Self().randUInt()
     }
 }

--- a/Sources/Random/URandom.swift
+++ b/Sources/Random/URandom.swift
@@ -6,7 +6,7 @@ import libc
     /dev/urandom is a cryptographically secure random generator provided by the OS.
 */
 public final class URandom: Random {
-    private let file = fopen("/dev/urandom", "r")
+    private let file = fopen("/dev/urandom", "rb")
     
     /// Initialize URandom
     public init() {}
@@ -16,10 +16,13 @@ public final class URandom: Random {
     }
     
     private func read(numBytes: Int) -> [Int8] {
-        // Initialize an empty array with numBytes+1 for null terminated string
-        var bytes = [Int8](repeating: 0, count: numBytes + 1)
-        fgets(&bytes, numBytes + 1, file)
-        bytes.removeLast()
+        // Initialize an empty array with space for numBytes bytes
+        var bytes = [Int8](repeating: 0, count: numBytes)
+		guard fread(&bytes, 1, numBytes, file) == numBytes else {
+			// If the requested number of random bytes couldn't be read,
+			// we need to fail fast and hard.
+			abort()
+		}
         return bytes
     }
     

--- a/Sources/Random/URandom.swift
+++ b/Sources/Random/URandom.swift
@@ -7,8 +7,8 @@ import libc
 */
 public final class URandom: Random {
     public enum Error: Swift.Error {
-        case open(errno_t)
-        case read(errno_t)
+        case open(Int32)
+        case read(Int32)
     }
 
     private let file = fopen("/dev/urandom", "rb")

--- a/Sources/Random/URandom.swift
+++ b/Sources/Random/URandom.swift
@@ -6,28 +6,39 @@ import libc
     /dev/urandom is a cryptographically secure random generator provided by the OS.
 */
 public final class URandom: Random {
+    public enum Error: Swift.Error {
+        case open(errno_t)
+        case read(errno_t)
+    }
+
     private let file = fopen("/dev/urandom", "rb")
-    
+
     /// Initialize URandom
     public init() {}
-    
+
     deinit {
         fclose(file)
     }
-    
-    private func read(numBytes: Int) -> [Int8] {
+
+    private func read(numBytes: Int) throws -> [Int8] {
+        // The Random protocol doesn't allow init to fail, so we have to
+        // check whether /dev/urandom was successfully opened here
+        guard file != nil else {
+            throw Error.open(errno)
+        }
+
         // Initialize an empty array with space for numBytes bytes
         var bytes = [Int8](repeating: 0, count: numBytes)
-		guard fread(&bytes, 1, numBytes, file) == numBytes else {
-			// If the requested number of random bytes couldn't be read,
-			// we need to fail fast and hard.
-			abort()
-		}
+        guard fread(&bytes, 1, numBytes, file) == numBytes else {
+            // If the requested number of random bytes couldn't be read,
+            // we need to throw an error
+            throw Error.read(errno)
+        }
         return bytes
     }
-    
-    /// Get a byte array of random UInt8s
-    public func bytes(_ num: Int) -> Bytes {
-        return read(numBytes: num).map({ Byte(bitPattern: $0) })
+
+    /// Get a random array of Bytes
+    public func bytes(count: Int) throws -> Bytes {
+        return try read(numBytes: count).map({ Byte(bitPattern: $0) })
     }
 }

--- a/Tests/BCryptTests/BCryptTests.swift
+++ b/Tests/BCryptTests/BCryptTests.swift
@@ -68,9 +68,9 @@ class BCryptTests: XCTestCase {
         }
     }
     
-    func testBCryptGeneratesSalts() {
-        let salt = BCryptSalt()
-        let salt12 = BCryptSalt(cost: 12)
+    func testBCryptGeneratesSalts() throws {
+        let salt = try BCryptSalt(costFactor: nil)
+        let salt12 = try BCryptSalt(costFactor: 12)
         
         XCTAssert(salt.string.hasPrefix("$2a$10"), "The prefix should be $2a (for BCrypt) and $10 (iterations)")
         XCTAssertEqual(salt.string.characters.count, 29, "The salt should always be 29 characters")
@@ -81,7 +81,7 @@ class BCryptTests: XCTestCase {
     
     func testBCryptHashesPasswordsProperly() throws {
         for test in tests {
-            XCTAssertEqual(try BCrypt.hash(password: test.0, salt: BCryptSalt(string: test.1)), test.2, "The hashed password should match the precomputed hash")
+            XCTAssertEqual(try BCrypt.digest(password: test.0, salt: BCryptSalt(string: test.1)), test.2, "The hashed password should match the precomputed hash")
         }
     }
     

--- a/Tests/CipherTests/CipherTests.swift
+++ b/Tests/CipherTests/CipherTests.swift
@@ -33,7 +33,7 @@ class CipherTests: XCTestCase {
     func testOverflow() throws {
         let key = "passwordpasswordpasswordpassword".makeBytes()
         let iv = "passwordpassword".makeBytes()
-        let plaintext = URandom.bytes(65_536)
+        let plaintext = try URandom.bytes(count: 65_536)
 
         let cipher = try Cipher(.aes256(.cbc), key: key, iv: iv)
         let encrypted = try cipher.encrypt(plaintext)

--- a/Tests/RandomTests/RandomTests.swift
+++ b/Tests/RandomTests/RandomTests.swift
@@ -6,21 +6,35 @@ class RandomTests: XCTestCase {
     static var allTests = [
         ("testURandom", testURandom),
         ("testCryptoRandom", testCryptoRandom),
-        ("testPsuedoRandom", testPsuedoRandom),
+        ("testPseudoRandom", testPseudoRandom),
+        ("testRandomCount", testRandomCount),
+        ("testForTrailingZeros", testForTrailingZeros),
     ]
 
     func testURandom() throws {
-        let rand = URandom.int8
+        let rand = try URandom.randInt8()
         print(rand)
     }
 
     func testCryptoRandom() throws {
-        let rand = URandom.uint32
+        let rand = try CryptoRandom.randUInt32()
         print(rand)
     }
 
-    func testPsuedoRandom() throws {
-        let rand = URandom.int64
+    func testPseudoRandom() throws {
+        let rand = try PseudoRandom.randInt64()
         print(rand)
+    }
+
+    func testRandomCount() throws {
+        let rand = try URandom.bytes(count: 65_536)
+        XCTAssertEqual(rand.count, 65_536)
+    }
+
+    func testForTrailingZeros() throws {
+        let rand = try URandom.bytes(count: 65_536)
+        let tail = Bytes(rand.suffix(8))
+        let zeros = Bytes(repeating: 0, count: 8)
+        XCTAssertNotEqual(tail, zeros)
     }
 }


### PR DESCRIPTION
The biggest issue solved by this PR is that `URandom` incorrectly reads from /dev/urandom as string data. /dev/urandom contains binary data that must not be treated as a string. Currently, bytes are being read from this device using `fgets()`. [`man 3 fgets`](https://linux.die.net/man/3/fgets) says the following:

> Reading stops after an **EOF** or a newline.

Because of this, if one of the bytes from /dev/urandom happens to be a newline (maybe `\0` as well), then `fgets()` will stop reading. That means the rest of the bytes from this point on will be all zeros.

This is evident by visual inspection of the output from `URandom()` as well. For example, I'm using `URandom` to generate secure tokens for use as session tokens among other things. I looked at the tokens stored and found the following: `WPxXr5UKAAAAAAAAAAAAAA`. The `A`s at the end are the base64 representation of zero bytes. In addition to this, every single token in the database ends with one of 4 characters: `Q`, `g`, `w`, or `A`. The tokens I am generating are only 16 bytes of randomness, but the issue is even more evident for larger chunks of random data, since every byte read has a 1/256 (1/128 if `\0` also makes `fgets()` stop reading) chance of making every byte after that be zero.

In addition to fixing this issue by changing from `fgets()` to `fread()` (which _can_ be used to read binary data), the return code of all random data reading functions is checked to ensure they successfully returned the requested number of securely random bytes. For the `CryptoRandom` and `PseudoRandom` classes, I read [`man 3 RAND_bytes`](https://linux.die.net/man/3/rand_bytes) to find that these functions return 1 on success.