### PR TITLE
Fix Cipher Context Leak

### DIFF
--- a/Sources/Crypto/Cipher/Cipher.swift
+++ b/Sources/Crypto/Cipher/Cipher.swift
@@ -121,6 +121,8 @@ public final class Cipher {
         defer {
             buffer.deinitialize()
             buffer.deallocate(capacity: bufferLength)
+
+            EVP_CIPHER_CTX_cleanup(&ctx)
         }
 
         var endLength: Int32 = 0


### PR DESCRIPTION
Corrects a memory leak of 272 bytes every time `Cipher.encrypt` or `Cipher.decrypt` is called.