### PR TITLE
add RSA

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,6 @@ let package = Package(
         .package(url: "https://github.com/vapor/core.git", from: "3.0.0-rc"),
     ],
     targets: [
-        .target(name: "Crypto", dependencies: ["Async", "Bits", "COperatingSystem", "Debugging"]),
         .testTarget(name: "CryptoTests", dependencies: ["Crypto"]),
         .target(name: "Pufferfish"),
         .testTarget(name: "PufferfishTests", dependencies: ["Pufferfish"]),
@@ -24,3 +23,10 @@ let package = Package(
         .testTarget(name: "RandomTests", dependencies: ["Random"]),
     ]
 )
+
+#if os(macOS)
+package.targets.append(.target(name: "Crypto", dependencies: ["Async", "Bits", "COperatingSystem", "Debugging"]))
+#else
+package.dependencies.append(.package(url: "https://github.com/vapor/copenssl.git", from: "1.0.0-rc"))
+package.targets.append(.target(name: "Crypto", dependencies: ["Async", "Bits", "COperatingSystem", "COpenSSL", "Debugging"]))
+#endif

--- a/Sources/Crypto/RSA/AppleRSA.swift
+++ b/Sources/Crypto/RSA/AppleRSA.swift
@@ -3,32 +3,29 @@
 import Foundation
 import Security
 
-struct AppleRSA {
-    static func makeCiphertext(from plaintext: Data, privateKey: Data) throws -> Data {
-        if #available(OSX 10.12, *) {
-            let options: [String: Any] = [
-                kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
-                kSecAttrKeyClass as String: kSecAttrKeyClassPrivate,
-                kSecAttrKeySizeInBits as String: 2048
-            ]
-            var error: Unmanaged<CFError>?
-            guard let privateKey = SecKeyCreateWithData(
-                privateKey as CFData,
-                options as CFDictionary,
-                &error
-            ) else {
-                throw error!.takeRetainedValue() as Error
-            }
+extension RSAKeyType {
+    var `class`: CFString {
+        switch self {
+        case .private: return kSecAttrKeyClassPrivate
+        case .public: return kSecAttrKeyClassPublic
+        }
+    }
+}
 
-            let algorithm: SecKeyAlgorithm = .rsaSignatureMessagePKCS1v15SHA512
-            guard SecKeyIsAlgorithmSupported(privateKey, .sign, algorithm) else {
+struct AppleRSA {
+    static func sign(_ input: Data, for rsa: RSA) throws -> Data {
+        if #available(OSX 10.12, *) {
+            let key = try rsa.makeSecKey()
+            let algorithm: SecKeyAlgorithm = rsa.secAlgorithm
+            guard SecKeyIsAlgorithmSupported(key, .sign, algorithm) else {
                 fatalError()
             }
 
+            var error: Unmanaged<CFError>?
             guard let signature = SecKeyCreateSignature(
-                privateKey,
+                key,
                 algorithm,
-                plaintext as CFData,
+                input as CFData,
                 &error
             ) as Data? else {
                 throw error!.takeRetainedValue() as Error
@@ -40,36 +37,105 @@ struct AppleRSA {
         }
     }
 
-    static func verifyCiphertext(_ ciphertext: Data, matches plaintext: Data, publicKey: Data) throws -> Bool {
-        if #available(OSX 10.12, *) {
-            let options: [String: Any] = [
-                kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
-                kSecAttrKeyClass as String: kSecAttrKeyClassPublic,
-                kSecAttrKeySizeInBits as String: 2048
-            ]
-            var error: Unmanaged<CFError>?
-            guard let publicKey = SecKeyCreateWithData(
-                publicKey as CFData,
-                options as CFDictionary,
-                &error
-            ) else {
-                throw error!.takeRetainedValue() as Error
-            }
+    static func verify(signature: Data, matches input: Data, for rsa: RSA) throws -> Bool {
+        switch rsa.key.type {
+        case .private:
+            return try sign(input, for: rsa) == signature
+        case .public:
+            if #available(OSX 10.12, *) {
+                let key = try rsa.makeSecKey()
+                let algorithm: SecKeyAlgorithm = rsa.secAlgorithm
+                guard SecKeyIsAlgorithmSupported(key, .verify, algorithm) else {
+                    fatalError()
+                }
 
-            let algorithm: SecKeyAlgorithm = .rsaSignatureMessagePKCS1v15SHA512
-            guard SecKeyIsAlgorithmSupported(publicKey, .verify, algorithm) else {
-                fatalError()
+                var error: Unmanaged<CFError>?
+                let value = SecKeyVerifySignature(
+                    key,
+                    algorithm,
+                    input as CFData,
+                    signature as CFData,
+                    &error
+                )
+                if let error = error?.takeRetainedValue() {
+                    throw error as Error
+                }
+                return value
+            } else {
+                fatalError("macOS 10.12 or later required for RSA")
             }
+        }
+    }
+}
 
-            return SecKeyVerifySignature(
-                publicKey,
-                algorithm,
-                plaintext as CFData,
-                ciphertext as CFData,
-                &error
-            )
-        } else {
-            fatalError("macOS 10.12 or later required for RSA")
+extension RSA {
+    @available(OSX 10.12, *)
+    func makeSecKey() throws -> SecKey {
+        let options: [String: Any] = [
+            kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
+            kSecAttrKeyClass as String: key.type.class,
+            kSecAttrKeySizeInBits as String: key.bits
+        ]
+        var error: Unmanaged<CFError>?
+        guard let key = SecKeyCreateWithData(
+            key.data as CFData,
+            options as CFDictionary,
+            &error
+        ) else {
+            throw error!.takeRetainedValue() as Error
+        }
+        return key
+    }
+
+    @available(OSX 10.12, *)
+    var secAlgorithm: SecKeyAlgorithm {
+        switch inputFormat {
+        case .digest:
+            switch paddingScheme {
+            case .pkcs1:
+                switch hashAlgorithm {
+                case .sha1: return .rsaSignatureDigestPKCS1v15SHA1
+                case .sha224: return .rsaSignatureDigestPKCS1v15SHA224
+                case .sha256: return .rsaSignatureDigestPKCS1v15SHA256
+                case .sha384: return .rsaSignatureDigestPKCS1v15SHA384
+                case .sha512: return .rsaSignatureDigestPKCS1v15SHA512
+                }
+            case .pss:
+                if #available(OSX 10.13, *) {
+                    switch hashAlgorithm {
+                    case .sha1: return .rsaSignatureDigestPSSSHA1
+                    case .sha224: return .rsaSignatureDigestPSSSHA224
+                    case .sha256: return .rsaSignatureDigestPSSSHA256
+                    case .sha384: return .rsaSignatureDigestPSSSHA384
+                    case .sha512: return .rsaSignatureDigestPSSSHA512
+                    }
+                } else {
+                    fatalError()
+                }
+            }
+        case .message:
+            switch paddingScheme {
+            case .pkcs1:
+                switch hashAlgorithm {
+                case .sha1: return .rsaSignatureMessagePKCS1v15SHA1
+                case .sha224: return .rsaSignatureMessagePKCS1v15SHA224
+                case .sha256: return .rsaSignatureMessagePKCS1v15SHA256
+                case .sha384: return .rsaSignatureMessagePKCS1v15SHA384
+                case .sha512: return .rsaSignatureMessagePKCS1v15SHA512
+                }
+            case .pss:
+                if #available(OSX 10.13, *) {
+                    switch hashAlgorithm {
+                    case .sha1: return .rsaSignatureMessagePSSSHA1
+                    case .sha224: return .rsaSignatureMessagePSSSHA224
+                    case .sha256: return .rsaSignatureMessagePSSSHA256
+                    case .sha384: return .rsaSignatureMessagePSSSHA384
+                    case .sha512: return .rsaSignatureMessagePSSSHA512
+                    }
+                } else {
+                    fatalError()
+                }
+            }
         }
     }
 }

--- a/Sources/Crypto/RSA/AppleRSA.swift
+++ b/Sources/Crypto/RSA/AppleRSA.swift
@@ -1,0 +1,77 @@
+#if os(macOS)
+
+import Foundation
+import Security
+
+struct AppleRSA {
+    static func makeCiphertext(from plaintext: Data, privateKey: Data) throws -> Data {
+        if #available(OSX 10.12, *) {
+            let options: [String: Any] = [
+                kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
+                kSecAttrKeyClass as String: kSecAttrKeyClassPrivate,
+                kSecAttrKeySizeInBits as String: 2048
+            ]
+            var error: Unmanaged<CFError>?
+            guard let privateKey = SecKeyCreateWithData(
+                privateKey as CFData,
+                options as CFDictionary,
+                &error
+            ) else {
+                throw error!.takeRetainedValue() as Error
+            }
+
+            let algorithm: SecKeyAlgorithm = .rsaSignatureMessagePKCS1v15SHA512
+            guard SecKeyIsAlgorithmSupported(privateKey, .sign, algorithm) else {
+                fatalError()
+            }
+
+            guard let signature = SecKeyCreateSignature(
+                privateKey,
+                algorithm,
+                plaintext as CFData,
+                &error
+            ) as Data? else {
+                throw error!.takeRetainedValue() as Error
+            }
+
+            return signature
+        } else {
+            fatalError("macOS 10.12 or later required for RSA")
+        }
+    }
+
+    static func verifyCiphertext(_ ciphertext: Data, matches plaintext: Data, publicKey: Data) throws -> Bool {
+        if #available(OSX 10.12, *) {
+            let options: [String: Any] = [
+                kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
+                kSecAttrKeyClass as String: kSecAttrKeyClassPublic,
+                kSecAttrKeySizeInBits as String: 2048
+            ]
+            var error: Unmanaged<CFError>?
+            guard let publicKey = SecKeyCreateWithData(
+                publicKey as CFData,
+                options as CFDictionary,
+                &error
+            ) else {
+                throw error!.takeRetainedValue() as Error
+            }
+
+            let algorithm: SecKeyAlgorithm = .rsaSignatureMessagePKCS1v15SHA512
+            guard SecKeyIsAlgorithmSupported(publicKey, .verify, algorithm) else {
+                fatalError()
+            }
+
+            return SecKeyVerifySignature(
+                publicKey,
+                algorithm,
+                plaintext as CFData,
+                ciphertext as CFData,
+                &error
+            )
+        } else {
+            fatalError("macOS 10.12 or later required for RSA")
+        }
+    }
+}
+
+#endif

--- a/Sources/Crypto/RSA/OpenSSLRSA.swift
+++ b/Sources/Crypto/RSA/OpenSSLRSA.swift
@@ -4,12 +4,73 @@ import Foundation
 import COpenSSL
 
 struct OpenSSLRSA {
-    static func makeCiphertext(from plaintext: Data, privateKey: Data) throws -> Data {
+    static func sign(_ input: Data, for rsa: RSA) throws -> Data {
+        let key = try rsa.key.makeOpenSSLKey()
 
+        // verify private
+
+        var siglen: UInt32 = 0
+        var sig = [UInt8](
+            repeating: 0,
+            count: Int(RSA_size(key.cKey))
+        )
+
+        let digest = try Hash(hashMethod.method, message).hash()
+
+        let ret = RSA_sign(
+            hashMethod.type,
+            digest,
+            UInt32(digest.count),
+            &sig,
+            &siglen,
+            cKey
+        )
+
+        guard ret == 1 else {
+            let reason: UnsafeMutablePointer<Int8>? = nil
+            ERR_error_string(ERR_get_error(), reason)
+            if let reason = reason {
+                let string = String(validatingUTF8: reason) ?? ""
+                print("[JWT] Signing error: \(string)")
+            }
+            throw JWTError.signing
+        }
+
+        return sig
     }
 
-    static func verifyCiphertext(_ ciphertext: Data, matches plaintext: Data, publicKey: Data) throws -> Bool {
+    static func verify(signature: Data, matches input: Data, for rsa: RSA) throws -> Bool {
+        let key = try rsa.key.makeOpenSSLKey()
 
+    }
+}
+
+final class CRSAKey {
+    let cKey: UnsafeMutablePointer<RSA>
+
+    init(cKey: UnsafeMutablePointer<RSA>) {
+        self.cKey = cKey
+    }
+
+    deinit {
+        RSA_free(cKey)
+    }
+}
+
+extension RSAKey {
+    func makeOpenSSLKey() throws -> CRSAKey {
+        let maybeKey = data.withUnsafeBufferPointer { ptr -> UnsafeMutablePointer<RSA>? in
+            var base = ptr.baseAddress
+            switch type {
+            case .public: return d2i_RSA_PUBKEY(nil, &base, data.count)
+            case .private: return d2i_RSAPrivateKey(nil, &base, data.count)
+            }
+        }
+
+        guard let cKey = maybeKey else {
+            fatalError()
+        }
+        return CRSAKey(cKey: cKey)
     }
 }
 

--- a/Sources/Crypto/RSA/OpenSSLRSA.swift
+++ b/Sources/Crypto/RSA/OpenSSLRSA.swift
@@ -1,0 +1,16 @@
+#if os(Linux)
+
+import Foundation
+import COpenSSL
+
+struct OpenSSLRSA {
+    static func makeCiphertext(from plaintext: Data, privateKey: Data) throws -> Data {
+
+    }
+
+    static func verifyCiphertext(_ ciphertext: Data, matches plaintext: Data, publicKey: Data) throws -> Bool {
+
+    }
+}
+
+#endif

--- a/Sources/Crypto/RSA/RSA.swift
+++ b/Sources/Crypto/RSA/RSA.swift
@@ -1,27 +1,121 @@
 import Foundation
 
-public struct RSA {
-    public var jwtAlgorithmName: String
-    let privateKey: Data
-    let publicKey: Data
+/// Represents an in-memory RSA key.
+public struct RSAKey {
+    /// The bit-count of this RSA key.
+    public var bits: Int
 
-    public init(privateKey: Data, publicKey: Data) {
-        self.privateKey = privateKey
-        self.publicKey = publicKey
-        self.jwtAlgorithmName = "rsa"
+    /// The specific RSA key type. Either public or private.
+    ///
+    /// Note: public keys can only verify signatures. A private key
+    /// is required to create new signatures.
+    public var type: RSAKeyType
+
+    /// The raw RSA key data. This data should have
+    /// already been base-64 decoded.
+    ///
+    /// Note: The length of this data does not need to equal
+    /// the `bits` count. RSA public/private keys have different
+    /// and varying lengths.
+    public var data: Data
+
+    public init(bits: Int, type: RSAKeyType, data: Data) {
+        self.bits = bits
+        self.type = type
+        self.data = data
     }
 
-    public func makeCiphertext(from plaintext: Data) throws -> Data {
+    /// MARK: Convenience
+    public static func public512(_ data: Data) -> RSAKey { return .init(bits: 512, type: .public, data: data) }
+    public static func public1024(_ data: Data) -> RSAKey { return .init(bits: 1024, type: .public, data: data) }
+    public static func public2048(_ data: Data) -> RSAKey { return .init(bits: 2048, type: .public, data: data) }
+    public static func public4096(_ data: Data) -> RSAKey { return .init(bits: 4096, type: .public, data: data) }
+    public static func private512(_ data: Data) -> RSAKey { return .init(bits: 512, type: .private, data: data) }
+    public static func private1024(_ data: Data) -> RSAKey { return .init(bits: 1024, type: .private, data: data) }
+    public static func private2048(_ data: Data) -> RSAKey { return .init(bits: 2048, type: .private, data: data) }
+    public static func private4096(_ data: Data) -> RSAKey { return .init(bits: 4096, type: .private, data: data) }
+}
+
+/// Supported RSA key types.
+public enum RSAKeyType {
+    /// A public RSA key. Used for verifying signatures.
+    case `public`
+    /// A private RSA key. Used for creating and verifying signatures.
+    case `private`
+}
+
+/// Supported RSA input formats.
+public enum RSAInputFormat {
+    /// The input has been hash already.
+    case digest
+    /// Raw, unhashed message
+    case message
+}
+
+/// Supported RSA hash types.
+public enum RSAHashAlgorithm {
+    /// SHA-1 hash.
+    case sha1
+    /// SHA-2 224 bit hash.
+    case sha224
+    /// SHA-2 256 bit hash.
+    case sha256
+    /// SHA-2 284 bit hash.
+    case sha384
+    /// SHA-2 512 bit hash.
+    case sha512
+}
+
+/// Supported RSA padding type.
+public enum RSAPaddingScheme {
+    /// PKCS#1
+    case pkcs1
+    /// Probabilistic Signature Scheme
+    case pss
+}
+
+/// RSA cipher.
+public struct RSA {
+    /// This cipher's key.
+    public let key: RSAKey
+
+    /// The hashing algorithm to use/used.
+    public let hashAlgorithm: RSAHashAlgorithm
+
+    /// The padding algorithm used.
+    public let paddingScheme: RSAPaddingScheme
+
+    /// The input format type.
+    public let inputFormat: RSAInputFormat
+
+    /// Creates a new RSA cipher.
+    public init(
+        hashAlgorithm: RSAHashAlgorithm = .sha512,
+        paddingScheme: RSAPaddingScheme = .pkcs1,
+        inputFormat: RSAInputFormat = .message,
+        key: RSAKey
+    ) {
+        self.hashAlgorithm = hashAlgorithm
+        self.paddingScheme = paddingScheme
+        self.inputFormat = inputFormat
+        self.key = key
+    }
+
+    /// Signs the supplied input (in format specified by `inputFormat`)
+    /// returning signature data.
+    public func sign(_ input: Data) throws -> Data {
         #if os(macOS)
-        return try AppleRSA.makeCiphertext(from: plaintext, privateKey: privateKey)
+        return try AppleRSA.sign(input, for: self)
         #else
         fatalError("Only macOS supported.")
         #endif
     }
 
-    public func verifyCiphertext(_ ciphertext: Data, matches plaintext: Data) throws -> Bool {
+    /// Verifies a signature *created using RSA with identical hash and padding settings)
+    /// matches supplied input (in format specified by `inputFormat`).
+    public func verify(signature: Data, matches input: Data) throws -> Bool {
         #if os(macOS)
-        return try AppleRSA.verifyCiphertext(ciphertext, matches: plaintext, publicKey: publicKey)
+        return try AppleRSA.verify(signature: signature, matches: input, for: self)
         #else
         fatalError("Only macOS supported.")
         #endif

--- a/Sources/Crypto/RSA/RSA.swift
+++ b/Sources/Crypto/RSA/RSA.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public struct RSA {
+    public var jwtAlgorithmName: String
+    let privateKey: Data
+    let publicKey: Data
+
+    public init(privateKey: Data, publicKey: Data) {
+        self.privateKey = privateKey
+        self.publicKey = publicKey
+        self.jwtAlgorithmName = "rsa"
+    }
+
+    public func makeCiphertext(from plaintext: Data) throws -> Data {
+        #if os(macOS)
+        return try AppleRSA.makeCiphertext(from: plaintext, privateKey: privateKey)
+        #else
+        fatalError("Only macOS supported.")
+        #endif
+    }
+
+    public func verifyCiphertext(_ ciphertext: Data, matches plaintext: Data) throws -> Bool {
+        #if os(macOS)
+        return try AppleRSA.verifyCiphertext(ciphertext, matches: plaintext, publicKey: publicKey)
+        #else
+        fatalError("Only macOS supported.")
+        #endif
+    }
+}

--- a/Sources/Crypto/RSA/RSA.swift
+++ b/Sources/Crypto/RSA/RSA.swift
@@ -1,3 +1,4 @@
+import Debugging
 import Foundation
 
 /// Represents an in-memory RSA key.
@@ -107,17 +108,26 @@ public struct RSA {
         #if os(macOS)
         return try AppleRSA.sign(input, for: self)
         #else
-        fatalError("Only macOS supported.")
+        return try OpenSSLRSA.sign(input, for: self)
         #endif
     }
 
     /// Verifies a signature *created using RSA with identical hash and padding settings)
     /// matches supplied input (in format specified by `inputFormat`).
-    public func verify(signature: Data, matches input: Data) throws -> Bool {
+    public func verify(_ signature: Data, signs input: Data) throws -> Bool {
         #if os(macOS)
         return try AppleRSA.verify(signature: signature, matches: input, for: self)
         #else
-        fatalError("Only macOS supported.")
+        return try OpenSSLRSA.verify(signature: signature, matches: input, for: self)
         #endif
     }
+}
+
+/// An error encountered while working with RSA ciphers.
+public struct RSAError: Debuggable {
+    /// See `Debuggable.identifier`
+    public var identifier: String
+
+    /// See `Debuggable.reason`
+    public var reason: String
 }

--- a/Tests/CryptoTests/RSATests.swift
+++ b/Tests/CryptoTests/RSATests.swift
@@ -3,21 +3,27 @@ import Bits
 import Crypto
 
 class RSATests: XCTestCase {
-    func testBasic() throws {
+    func testPrivateKey() throws {
         let privateKey = try Base64Decoder(encoding: .base64).decode(string: privateKeyString)
-        let publicKey = try Base64Decoder(encoding: .base64).decode(string: publicKeyString)
         let plaintext = Data("vapor".utf8)
-        let rsa = RSA(privateKey: privateKey, publicKey: publicKey)
-        let sig = try rsa.makeCiphertext(from: plaintext)
-        let matches = try rsa.verifyCiphertext(sig, matches: plaintext)
-        XCTAssertEqual(matches, true)
+        let rsa = RSA(key: .private2048(privateKey))
+        try XCTAssertTrue(rsa.verify(signature: rsa.sign(plaintext), matches: plaintext))
     }
 
+    func testPublicKey() throws {
+        let publicKey = try Base64Decoder(encoding: .base64).decode(string: publicKeyString)
+        let plaintext = Data("vapor".utf8)
+        let rsa = RSA(key: .public2048(publicKey))
+        try XCTAssertTrue(rsa.verify(signature: testSignature, matches: plaintext))
+    }
 
     static var allTests = [
-        ("testBasic", testBasic),
+        ("testPrivateKey", testPrivateKey),
+        ("testPublicKey", testPublicKey),
     ]
 }
+
+let testSignature = Data([89, 214, 169, 236, 21, 246, 207, 217, 142, 28, 105, 179, 141, 64, 202, 250, 90, 130, 245, 201, 158, 123, 23, 75, 95, 235, 116, 103, 240, 91, 211, 185, 117, 143, 222, 94, 247, 165, 211, 71, 97, 251, 23, 3, 160, 69, 127, 22, 112, 251, 111, 196, 212, 36, 255, 229, 91, 79, 220, 158, 241, 117, 253, 95, 23, 196, 41, 54, 96, 191, 42, 126, 249, 32, 110, 147, 165, 231, 108, 29, 231, 75, 80, 104, 217, 157, 134, 198, 138, 111, 188, 235, 171, 100, 59, 21, 244, 33, 176, 234, 22, 77, 202, 164, 38, 50, 183, 16, 45, 106, 225, 228, 20, 136, 87, 204, 192, 243, 177, 208, 157, 151, 194, 252, 223, 152, 165, 34, 143, 125, 162, 51, 162, 86, 203, 191, 216, 170, 184, 67, 145, 6, 75, 46, 66, 203, 47, 54, 106, 98, 136, 143, 190, 234, 233, 113, 132, 217, 61, 25, 73, 202, 30, 210, 185, 5, 52, 153, 165, 119, 215, 196, 79, 118, 83, 79, 184, 142, 255, 54, 209, 12, 227, 247, 63, 228, 84, 92, 109, 84, 238, 132, 29, 8, 175, 156, 97, 156, 176, 67, 24, 95, 182, 27, 191, 44, 117, 163, 89, 253, 105, 212, 81, 80, 130, 217, 24, 99, 34, 21, 103, 225, 60, 201, 54, 16, 132, 15, 22, 139, 41, 96, 74, 173, 224, 128, 63, 9, 238, 59, 102, 250, 44, 63, 66, 13, 82, 98, 93, 163, 73, 142, 74, 125, 172, 247])
 
 let privateKeyString = """
 MIIEpAIBAAKCAQEAk+dWlCTQIr85rtUi56yD6FT6vuG68Q9xJ4B9bAo4wys+ndlP

--- a/Tests/CryptoTests/RSATests.swift
+++ b/Tests/CryptoTests/RSATests.swift
@@ -1,0 +1,58 @@
+import XCTest
+import Bits
+import Crypto
+
+class RSATests: XCTestCase {
+    func testBasic() throws {
+        let privateKey = try Base64Decoder(encoding: .base64).decode(string: privateKeyString)
+        let publicKey = try Base64Decoder(encoding: .base64).decode(string: publicKeyString)
+        let plaintext = Data("vapor".utf8)
+        let rsa = RSA(privateKey: privateKey, publicKey: publicKey)
+        let sig = try rsa.makeCiphertext(from: plaintext)
+        let matches = try rsa.verifyCiphertext(sig, matches: plaintext)
+        XCTAssertEqual(matches, true)
+    }
+
+
+    static var allTests = [
+        ("testBasic", testBasic),
+    ]
+}
+
+let privateKeyString = """
+MIIEpAIBAAKCAQEAk+dWlCTQIr85rtUi56yD6FT6vuG68Q9xJ4B9bAo4wys+ndlP
+SX0UQkrPOpnNZcsHOob6DbRI5Cc4qce00nNJAlCxYqAJDDDryyQEtUv8ghGGWnjU
+gBRytm39UM9s/UxyLfGWk3P1Z1us8q5RvsrceC28uG94Lr+w2XmcBwxP020qJIiU
+qOff8me1vI7vogvec3yO6pLvb1zcqMioKIdQ/kWjgMvhVyFyg44IqEI1iApjt05C
+jTQ30W1xyN/9b/cedQzEg8Nq2MQdhKCIZJh2vjSUuWOBCnx+ttErIYt0roisNj1O
+howtSM6k0vV1LPDrCjV7lFPmE1njwTfdV/vlcQIDAQABAoIBAGBwjt6oJmMRx139
+sfXYYmZiyuEeNRQsGn9EZAPHon14PCsW4IEtosEbIIa4dNq0CPGbw36eGI1UGbly
+86/p5igxT4jciym82HMr+Dny4yI4pR9m/EDLlITpsSw5JHsBls3oYmOhT9nmSB4x
+ljHO+vUN9alZXcc1zO3xQtDBsWdNG73YFRAv2HJ6us50wQXw4cEsuQo6X/fUREkB
+nznkArTcm/VcnZFaRUg4sXQBBQdy3LhRh3zQ5V64iBe9AWgenDv7tO5Bk8xhrLE/
+kBdvyrTsWKaKSSnes28oB5YLfbFpRYnYGGuaWbu5f0deOuQlS5F5HxuaHHsdRxaU
+Xee7BLECgYEA60QxWsXdeIWXmMhOoCapq6OTdaPVVzZfZc57s82xy5IgghBJj3up
+QbOIcfcBNTmpG4ohtB5EEmOozBKEm3dg09RF9aQ/t4Gx4TOmbtCt8IiuNAr4zj7+
+xsLWh1sWGK0UvZ1hkkKoFxHU7ienXCfhfiEjBLWtNGzVHieoIc1Ly00CgYEAoPAr
+Txegn2ZreU4vn6CP9pHIxY6JV7nFPbGng6q8hkMMCu7CY/w9UP9iZG6uvQcoSqGt
+7rIUUqYWUcf8qcAtvWyLTZmtkCm+LIHiJak4PZXwTrpYOZQScpBTw8ViuVREsJSw
+5oHgworZg3rD9oLbiSt+Iy//U14g7gzA7mJVyLUCgYEA6pHoX6gOpH8WYme9NSK3
+YwHKIa4DJVx6C2ivn9uD3QPKU8PnhB746CAX+AEd/DKMcH/uEMdoealSAH6qJtQE
+/8+THVLxkIbIk1BLLgv0kXHFtvAFmKXoosZa3UQtKNdRaakEQq8hJzdJRVbWICVH
+R9nEL4rwseedKd7CXUlyu7UCgYBrjnbzQfAn95QGGxm6zdzIxb9vQIZLaa0HQS6Z
+0UZzWGW4/L5Pgikcc8E3K71+OUVVM16BsuPgJH2wJD6Y2AX5nYwvzW/wc+VT623P
+C5u5lPZoNyN1P59gj1Jb+RO0ljvd41Gii9RBT/h0ZVyH6AZ+UuHW9GHoPnU1grKB
+3phELQKBgQDOWrOLmd/v43r99fxqrkZv9twFkAPlcpYOMn/SDpmJfWR3sGWCz5eI
+czQFrr4k36C5HwgornNShezXpbU9bGaG7zAdd3egdqjYeWQeqj/WQFAoP6+jA+yL
+hR/bpssdZZaF7Ah0AR/IHGgbNLAfdpGBjyEl1WRoq+tuJ9oMcbKezQ==
+""".replacingOccurrences(of: "\n", with: "")
+
+let publicKeyString = """
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAk+dWlCTQIr85rtUi56yD
+6FT6vuG68Q9xJ4B9bAo4wys+ndlPSX0UQkrPOpnNZcsHOob6DbRI5Cc4qce00nNJ
+AlCxYqAJDDDryyQEtUv8ghGGWnjUgBRytm39UM9s/UxyLfGWk3P1Z1us8q5Rvsrc
+eC28uG94Lr+w2XmcBwxP020qJIiUqOff8me1vI7vogvec3yO6pLvb1zcqMioKIdQ
+/kWjgMvhVyFyg44IqEI1iApjt05CjTQ30W1xyN/9b/cedQzEg8Nq2MQdhKCIZJh2
+vjSUuWOBCnx+ttErIYt0roisNj1OhowtSM6k0vV1LPDrCjV7lFPmE1njwTfdV/vl
+cQIDAQAB
+""".replacingOccurrences(of: "\n", with: "")

--- a/Tests/CryptoTests/RSATests.swift
+++ b/Tests/CryptoTests/RSATests.swift
@@ -7,19 +7,27 @@ class RSATests: XCTestCase {
         let privateKey = try Base64Decoder(encoding: .base64).decode(string: privateKeyString)
         let plaintext = Data("vapor".utf8)
         let rsa = RSA(key: .private2048(privateKey))
-        try XCTAssertTrue(rsa.verify(signature: rsa.sign(plaintext), matches: plaintext))
+        try XCTAssertTrue(rsa.verify(rsa.sign(plaintext), signs: plaintext))
     }
 
     func testPublicKey() throws {
         let publicKey = try Base64Decoder(encoding: .base64).decode(string: publicKeyString)
         let plaintext = Data("vapor".utf8)
         let rsa = RSA(key: .public2048(publicKey))
-        try XCTAssertTrue(rsa.verify(signature: testSignature, matches: plaintext))
+        try XCTAssertTrue(rsa.verify(testSignature, signs: plaintext))
+    }
+
+    func testFailure() throws {
+        let plaintext = Data("vapor".utf8)
+        let publicKey = try Base64Decoder(encoding: .base64).decode(string: publicKeyString)
+        let rsa = RSA(key: .public2048(publicKey))
+        try XCTAssertFalse(rsa.verify(Data("fake".utf8), signs: plaintext))
     }
 
     static var allTests = [
         ("testPrivateKey", testPrivateKey),
         ("testPublicKey", testPublicKey),
+        ("testFailure", testFailure),
     ]
 }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -7,4 +7,5 @@ XCTMain([
     testCase(PBKDF2Tests.allTests),
     testCase(SHA1Tests.allTests),
     testCase(SHA2Tests.allTests),
+    testCase(RSATests.allTests),
 ])

--- a/circle.yml
+++ b/circle.yml
@@ -12,6 +12,8 @@ jobs:
     docker:
       - image: norionomura/swift:swift-4.1-branch
     steps:
+      - run: apt-get update
+      - run: apt-get install -yq libssl-dev
       - checkout
       - run: swift build
       - run: swift test


### PR DESCRIPTION
- [x] macOS Security-based RSA
- [x] linux OpenSSL-based RSA
- [x] public, generic RSA impl based on both versions

```swift
import Crypto

let privateKey: Data = ...
let publicKey: Data = ...
let plaintext = Data("vapor".utf8)

// sign with private key
let privateRSA = RSA(key: .private2048(privateKey))
let signature = try privateRSA.sign(plaintext)

// verify with public key
let publicRSA = RSA(key: .public2048(publicKey))
if try publicRSA.verify(signature, signs: plaintext) { 
    print("signature verified") 
}
```