### PR TITLE
Failing "password" test

### DIFF
--- a/Tests/CryptoTests/BCryptTests.swift
+++ b/Tests/CryptoTests/BCryptTests.swift
@@ -8,7 +8,7 @@ class BCryptTests: XCTestCase {
         ("testInvalidSalt", testInvalidSalt),
         ("testVerify", testVerify),
         ("testNotVerify", testNotVerify),
-        ("testHashPassword", testHashPassword)
+        ("testInvalidCost", testInvalidCost)
     ]
 
     func testVersion() throws {
@@ -22,8 +22,8 @@ class BCryptTests: XCTestCase {
         XCTAssertEqual(res, false)
     }
     
-    func testHashPassword() throws {
-        XCTAssertNoThrow(try BCrypt.hash("password", cost: 2))
+    func testInvalidCost() throws {
+        XCTAssertThrowsError(try BCrypt.hash("foo", cost: 2))
     }
 
     func testInvalidSalt() throws {

--- a/Tests/CryptoTests/BCryptTests.swift
+++ b/Tests/CryptoTests/BCryptTests.swift
@@ -8,6 +8,7 @@ class BCryptTests: XCTestCase {
         ("testInvalidSalt", testInvalidSalt),
         ("testVerify", testVerify),
         ("testNotVerify", testNotVerify),
+        ("testHashPassword", testHashPassword)
     ]
 
     func testVersion() throws {
@@ -19,6 +20,10 @@ class BCryptTests: XCTestCase {
         let digest = try BCrypt.hash("foo", cost: 6)
         let res = try BCrypt.verify("bar", created: digest)
         XCTAssertEqual(res, false)
+    }
+    
+    func testHashPassword() throws {
+        XCTAssertNoThrow(try BCrypt.hash("password", cost: 2))
     }
 
     func testInvalidSalt() throws {


### PR DESCRIPTION
Add's a failing test case because for some reason hashing "password" at a cost of 2 fails