### PR TITLE
add random sorter for arrays

### DIFF
--- a/Sources/Random/Array+Random.swift
+++ b/Sources/Random/Array+Random.swift
@@ -14,4 +14,22 @@ extension Array {
         let index = random % UInt(count)
         return self[Int(index)]
     }
+    
+    /// Returns the elements of this array, sorted randomly using `OSRandom`.
+    public func randomized() -> [Element] {
+        var original = self
+        var randomized: [Element] = []
+        
+        let random = OSRandom()
+            .generateData(count: MemoryLayout<UInt>.size)
+            .cast(to: UInt.self)
+        
+        while original.count > 0 {
+            let index = Int(random % UInt(original.count))
+            let draw = original.remove(at: index)
+            randomized.append(draw)
+        }
+        
+        return randomized
+    }
 }

--- a/Tests/RandomTests/RandomTests.swift
+++ b/Tests/RandomTests/RandomTests.swift
@@ -44,4 +44,19 @@ class RandomTests: XCTestCase {
         }
         print(results)
     }
+    
+    func testArrayRandomized() throws {
+        let original = [4, 3, 5, 2, -1]
+        var random1 = original
+        var random2 = original
+        while random1 == original || random2 == original || random1 == random2 {
+            random1 = original.randomized()
+            random2 = original.randomized()
+        }
+        XCTAssertNotEqual(original, random1)
+        XCTAssertNotEqual(original, random2)
+        XCTAssertNotEqual(random1, random2)
+        XCTAssertEqual(original.sorted(by: <), random1.sorted(by: <))
+        XCTAssertEqual(original.sorted(by: <), random2.sorted(by: <))
+    }
 }


### PR DESCRIPTION
This addition provides a function to randomly sort an Array.

It would also address a Fluent enhancement request I made: https://github.com/vapor/fluent/issues/442. But it's better off in the Crypto package because the syntax for random ordering varies among database technologies (MySQL uses `rand()`, PostgreSQL uses `random()`...).