### PR TITLE
Add RSA encrypt and decrypt and adapt api

### DIFF
--- a/Sources/Crypto/RSA/RSA.swift
+++ b/Sources/Crypto/RSA/RSA.swift
@@ -17,15 +17,21 @@ import Foundation
 ///
 /// Read more about RSA on [Wikipedia](https://en.wikipedia.org/wiki/RSA_(cryptosystem)).
 public final class RSA {
+
+    typealias RSAPkeySymmetricCoder = @convention(c) (Int32, UnsafePointer<UInt8>?, UnsafeMutablePointer<UInt8>?, UnsafeMutablePointer<CNIOOpenSSL.RSA>?, Int32) -> Int32
+
     // MARK: Static
 
     /// RSA using SHA256 digest.
+    @available(*, deprecated, message: "Use sign(_:algorithm:format:key:) or verify(_:algorithm:signs:format:key:)")
     public static var SHA256: RSA { return .init(algorithm: .sha256) }
 
     /// RSA using SHA384 digest.
+    @available(*, deprecated, message: "Use sign(_:algorithm:format:key:) or verify(_:algorithm:signs:format:key:)")
     public static var SHA384: RSA { return .init(algorithm: .sha384) }
 
     /// RSA using SHA512 digest.
+    @available(*, deprecated, message: "Use sign(_:algorithm:format:key:) or verify(_:algorithm:signs:format:key:)")
     public static var SHA512: RSA { return .init(algorithm: .sha512) }
 
     // MARK: Properties
@@ -33,35 +39,39 @@ public final class RSA {
     /// The hashing algorithm to use, (e.g., SHA512). See `DigestAlgorithm`.
     public let algorithm: DigestAlgorithm
 
-    // MARK: Init
-
-    /// Creates a new RSA cipher using the supplied `DigestAlgorithm`.
-    ///
-    /// You can use the convenience static variables on `RSA` for common algorithms.
-    ///
-    ///     let ciphertext = try RSA.SHA512.sign("vapor", key: .private(pem: ...))
-    ///
-    /// You can also use this method to manually create an `RSA`.
-    ///
-    ///     let rsa = RSA(algorithm: .sha512)
-    ///
+    @available(*, deprecated, message: "Use sign(_:algorithm:format:key:) or verify(_:algorithm:signs:format:key:)")
     public init(algorithm: DigestAlgorithm) {
         self.algorithm = algorithm
     }
+
+    // MARK: Init
+
+    /// Creates a new RSA cipher with the default unsafe md4 DigestAlgorithm.
+    /// You should use the sign and verify methods to provide a safer algorithm.
+    public init() {
+        self.algorithm = .md4
+    }
+
+    @available(*, deprecated, message: "Use sign(_:algorithm:format:key:)")
+    public func sign(_ input: LosslessDataConvertible, format: RSAInputFormat = .message, key: RSAKey) throws -> Data {
+        return try sign(input, algorithm: self.algorithm, format: format, key: key)
+    }
+
 
     // MARK: Methods
 
     /// Signs the supplied input (in format specified by `format`).
     ///
-    ///     let ciphertext = try RSA.SHA512.sign("vapor", key: .private(pem: ...))
+    ///     let ciphertext = try RSA.SHA512.sign("vapor", algorithm: .sha256,key: .private(pem: ...))
     ///
     /// - parameters:
     ///     - input: Plaintext message or message digest to sign.
     ///     - format: Format of the input, either plaintext message or digest.
+    ///     - algorithm: Digest algorithm to use.
     ///     - key: `RSAKey` to use for signing this data.
     /// - returns: RSA signature for this data.
     /// - throws: `CryptoError` if signing fails or data conversion fails.
-    public func sign(_ input: LosslessDataConvertible, format: RSAInputFormat = .message, key: RSAKey) throws -> Data {
+    public func sign(_ input: LosslessDataConvertible, algorithm: DigestAlgorithm, format: RSAInputFormat = .message, key: RSAKey) throws -> Data {
         switch key.type {
         case .public: throw CryptoError(identifier: "rsaSign", reason: "Cannot create RSA signature with a public key. A private key is required.")
         case .private: break
@@ -80,20 +90,29 @@ public final class RSA {
         case .message: input = try Digest(algorithm: algorithm).hash(input)
         }
 
-        let ret = RSA_sign(
-            algorithm.type,
-            input.withUnsafeBytes { $0 },
-            UInt32(input.count),
-            sig.withUnsafeMutableBytes { $0 },
-            &siglen,
-            key.c.pointer
-        )
+        let ret = input.withByteBuffer { inputBuffer in
+            return sig.withMutableByteBuffer { sigBuffer in
+                return RSA_sign(
+                    algorithm.type,
+                    inputBuffer.baseAddress!,
+                    UInt32(inputBuffer.count),
+                    sigBuffer.baseAddress!,
+                    &siglen,
+                    key.c.pointer
+                )
+            }
+        }
 
         guard ret == 1 else {
             throw CryptoError.openssl(identifier: "rsaSign", reason: "RSA signature creation failed")
         }
 
         return sig
+    }
+
+    @available(*, deprecated, message: "Use verify(_:algorithm:signs:format:key:)")
+    public func verify(_ signature: LosslessDataConvertible, signs input: LosslessDataConvertible, format: RSAInputFormat = .message, key: RSAKey) throws -> Bool {
+        return try verify(signature, algorithm: self.algorithm, signs: input, format: format, key: key)
     }
 
     /// Returns `true` if the supplied signature was created by signing the plaintext data.
@@ -107,25 +126,80 @@ public final class RSA {
     ///     - key: `RSAKey` to use for signing this data.
     /// - returns: `true` if signature matches plaintext input.
     /// - throws: `CryptoError` if verification fails or data conversion fails.
-    public func verify(_ signature: LosslessDataConvertible, signs input: LosslessDataConvertible, format: RSAInputFormat = .message, key: RSAKey) throws -> Bool {
+    public func verify(_ signature: LosslessDataConvertible, algorithm: DigestAlgorithm, signs input: LosslessDataConvertible, format: RSAInputFormat = .message, key: RSAKey) throws -> Bool {
         var input = input.convertToData()
-        var signature = signature.convertToData()
+        let signature = signature.convertToData()
 
         switch format {
         case .digest: break // leave input as is
         case .message: input = try Digest(algorithm: algorithm).hash(input)
         }
 
-        let result = RSA_verify(
-            algorithm.type,
-            input.withUnsafeBytes { $0 },
-            UInt32(input.count),
-            signature.withUnsafeBytes { $0 },
-            UInt32(signature.count),
-            key.c.pointer
-        )
+        let result = input.withByteBuffer { inputBuffer in
+            return signature.withByteBuffer { signatureBuffer in
+                return RSA_verify(
+                    algorithm.type,
+                    inputBuffer.baseAddress!,
+                    UInt32(inputBuffer.count),
+                    signatureBuffer.baseAddress!,
+                    UInt32(signatureBuffer.count),
+                    key.c.pointer
+                )
+            }
+        }
         return result == 1
     }
+
+
+    /// Dencrypts the supplied input.
+    ///
+    ///     let decryptedData = try RSA().sign("vapor", padding: .pkcs1 ,key: .private(pem: ...))
+    ///
+    /// - parameters:
+    ///     - input: Encrypted message to decrypt.
+    ///     - padding: Padding used in the decryption.
+    ///     - key: `RSAKey` to use for decrypting this data.
+    /// - returns: Decrypted data.
+    /// - throws: `CryptoError` if encrypting fails.
+    public func decrypt(_ input: LosslessDataConvertible, padding: RSAPadding, key: RSAKey) throws -> Data {
+        return try rsaPkeyCrypt(input, padding: padding, key: key, coder: RSA_private_decrypt)
+    }
+
+    /// Encrypts the supplied input.
+    ///
+    ///     let encryptedData = try RSA().encrypt("vapor", padding: .pkcs1 ,key: .public(pem: ...))
+    ///
+    /// - parameters:
+    ///     - input: Plaintext message to encrypt.
+    ///     - padding: Padding used in the encryption.
+    ///     - key: `RSAKey` to use for encrypting this data.
+    /// - returns: Encrypted data.
+    /// - throws: `CryptoError` if encrypting fails.
+    public func encrypt(_ input: LosslessDataConvertible, padding: RSAPadding, key: RSAKey) throws -> Data {
+        return try rsaPkeyCrypt(input, padding: padding, key: key, coder: RSA_public_encrypt)
+    }
+
+    fileprivate func rsaPkeyCrypt(_ input: LosslessDataConvertible, padding: RSAPadding, key: RSAKey, coder: RSAPkeySymmetricCoder) throws -> Data {
+        var outputData = Data(count: Int(RSA_size(key.c.pointer)))
+
+        let outputLen = input.convertToData().withByteBuffer { inputBuffer in
+            return outputData.withMutableByteBuffer { outputBuffer -> Int32 in
+                return coder(
+                    Int32(inputBuffer.count), // flen - input length
+                    inputBuffer.baseAddress!, // from - input bytes
+                    outputBuffer.baseAddress!, // to - output buffer
+                    key.c.pointer, // rsa - the key itself
+                    padding.rawValue // padding - padding mode
+                )
+            }
+        }
+
+        guard outputLen >= 0 else {
+            throw CryptoError.openssl(identifier: "rsaPkeyCrypt", reason: "RSA data encryption operation failed")
+        }
+        return outputData.prefix(upTo: Int(outputLen))
+    }
+
 }
 
 /// Supported RSA input formats.

--- a/Sources/Crypto/RSA/RSAPadding.swift
+++ b/Sources/Crypto/RSA/RSAPadding.swift
@@ -1,0 +1,44 @@
+import CNIOOpenSSL
+import Foundation
+
+/// RSA Paddings
+public enum RSAPadding: Int32 {
+    case pkcs1
+    case sslv23
+    case none
+    case pkcs1_OAEP
+    case x931
+
+    public init?(rawValue: Int32) {
+        switch rawValue {
+        case RSA_PKCS1_PADDING:
+            self = .pkcs1
+        case RSA_SSLV23_PADDING:
+            self = .sslv23
+        case RSA_NO_PADDING:
+            self = .none
+        case RSA_PKCS1_OAEP_PADDING:
+            self = .pkcs1_OAEP
+        case RSA_X931_PADDING:
+            self = .x931
+        default:
+            return nil
+        }
+    }
+
+    public var rawValue: Int32 {
+        switch self {
+        case .pkcs1:
+            return RSA_PKCS1_PADDING
+        case .sslv23:
+            return RSA_SSLV23_PADDING
+        case .none:
+            return RSA_NO_PADDING
+        case .pkcs1_OAEP:
+            return RSA_PKCS1_OAEP_PADDING
+        case .x931:
+            return RSA_X931_PADDING
+        }
+    }
+
+}

--- a/Tests/CryptoTests/RSATests.swift
+++ b/Tests/CryptoTests/RSATests.swift
@@ -6,7 +6,7 @@ class RSATests: XCTestCase {
     func testPrivateKey() throws {
         let plaintext = Data("vapor".utf8)
         let key: RSAKey = try .private(pem: privateKeyString)
-        let ciphertext = try RSA.SHA512.sign(plaintext, key: key)
+        let ciphertext = try RSA().sign(plaintext, algorithm: .sha512, key: key)
         let verified = try RSA.SHA512.verify(ciphertext, signs: plaintext, key: key)
         XCTAssertTrue(verified)
     }
@@ -14,18 +14,18 @@ class RSATests: XCTestCase {
     func testPublicKey() throws {
         let plaintext = Data("vapor".utf8)
         let key: RSAKey = try .public(pem: publicKeyString)
-        try XCTAssertTrue(RSA.SHA512.verify(testSignature, signs: plaintext, key: key))
+        try XCTAssertTrue(RSA().verify(testSignature, algorithm: .sha512, signs: plaintext, key: key))
     }
 
     func testFailure() throws {
         let plaintext = Data("vapor".utf8)
         let key: RSAKey = try .public(pem: publicKeyString)
-        try XCTAssertFalse(RSA.SHA512.verify(Data("fake".utf8), signs: plaintext, key: key))
+        try XCTAssertFalse(RSA().verify(Data("fake".utf8), algorithm: .sha512, signs: plaintext, key: key))
     }
 
     func testKey1024() throws {
-        let ciphertext = try RSA.SHA512.sign("vapor", key: .private(pem: privateKey2String))
-        let verified = try RSA.SHA512.verify(ciphertext, signs: "vapor", key: .public(pem: publicKey2String))
+        let ciphertext = try RSA().sign("vapor", algorithm: .sha512, key: .private(pem: privateKey2String))
+        let verified = try RSA().verify(ciphertext, algorithm: .sha512, signs: "vapor", key: .public(pem: publicKey2String))
         XCTAssertTrue(verified)
     }
 
@@ -33,8 +33,8 @@ class RSATests: XCTestCase {
         let plaintext = Data("vapor".utf8)
         let rsaPublic: RSAKey = try .public(pem: publicKey3String)
         let rsaPrivate: RSAKey = try .private(pem: privateKey3String)
-        let ciphertext = try RSA.SHA512.sign(plaintext, key: rsaPrivate)
-        let verified = try RSA.SHA512.verify(ciphertext, signs: plaintext, key: rsaPublic)
+        let ciphertext = try RSA().sign(plaintext, algorithm: .sha512, key: rsaPrivate)
+        let verified = try RSA().verify(ciphertext, algorithm: .sha512, signs: plaintext, key: rsaPublic)
         XCTAssertTrue(verified)
     }
 
@@ -42,8 +42,8 @@ class RSATests: XCTestCase {
         let plaintext = Data("vapor".utf8)
         let rsaPublic: RSAKey = try .public(pem: publicKey4String)
         let rsaPrivate: RSAKey = try .private(pem: privateKey4String)
-        let ciphertext = try RSA.SHA512.sign(plaintext, key: rsaPrivate)
-        let verified = try RSA.SHA512.verify(ciphertext, signs: plaintext, key: rsaPublic)
+        let ciphertext = try RSA().sign(plaintext, algorithm: .sha512, key: rsaPrivate)
+        let verified = try RSA().verify(ciphertext, algorithm: .sha512, signs: plaintext, key: rsaPublic)
         XCTAssertTrue(verified)
     }
 
@@ -51,9 +51,19 @@ class RSATests: XCTestCase {
         let plaintext = Data("vapor".utf8)
         let rsaPublic: RSAKey = try .public(certificate: publicCertString)
         let rsaPrivate: RSAKey = try .private(pem: privateCertString)
-        let ciphertext = try RSA.SHA512.sign(plaintext, key: rsaPrivate)
-        let verified = try RSA.SHA512.verify(ciphertext, signs: plaintext, key: rsaPublic)
+        let ciphertext = try RSA().sign(plaintext, algorithm: .sha512, key: rsaPrivate)
+        let verified = try RSA().verify(ciphertext, algorithm: .sha512, signs: plaintext, key: rsaPublic)
         XCTAssertTrue(verified)
+    }
+
+    func testEncrypt() throws {
+        let plaintext = Data("vapor".utf8)
+        let rsaPublic: RSAKey = try .public(certificate: publicCertString)
+        let rsaPrivate: RSAKey = try .private(pem: privateCertString)
+        let encryptedData = try RSA().encrypt(plaintext, padding: .pkcs1, key: rsaPublic)
+        let decryptedData = try RSA().decrypt(encryptedData, padding: .pkcs1, key: rsaPrivate)
+        let decryptedPlaintext = String(data: decryptedData, encoding: .utf8)
+        XCTAssertTrue(decryptedData == "vapor")
     }
 
     func testRand() throws {


### PR DESCRIPTION
This PR adds encrypt and decrypt capabilities to the RSA class. Furthermore, the old .init with a digestAlgorithm didn't make sense anymore; therefore, I deprecated the old apis and introduced new methods which take a DigestAlgorithm as a parameter.