### PR TITLE
Convert CryptoRandom and OSRandom into structs to save allocations

### DIFF
--- a/Sources/Crypto/Random/CryptoRandom.swift
+++ b/Sources/Crypto/Random/CryptoRandom.swift
@@ -4,7 +4,7 @@ import Foundation
 import Random
 
 /// Uses OpenSSL `RAND_bytes` to generate random data.
-public final class CryptoRandom: DataGenerator {
+public struct CryptoRandom: DataGenerator {
     /// Creates a new `CryptoRandom`.
     public init() {}
 

--- a/Sources/Random/OSRandom.swift
+++ b/Sources/Random/OSRandom.swift
@@ -3,7 +3,7 @@ import Foundation
 import COperatingSystem
 
 /// Uses the operating system's Random function uses `random` on Linux and `arc4random` on macOS.
-public final class OSRandom: DataGenerator {
+public struct OSRandom: DataGenerator {
     /// Create a new `OSRandom`
     public init() {}
 


### PR DESCRIPTION
This saves an allocation whenever `CryptoRandom()` is called.