### PR TITLE
Make `makeRandom` public

### DIFF
--- a/Sources/Random/OSRandom.swift
+++ b/Sources/Random/OSRandom.swift
@@ -18,8 +18,9 @@ public struct OSRandom: DataGenerator {
 
         return bytes
     }
-
-    fileprivate func makeRandom(min: Int, max: Int) -> Int {
+    
+    /// Random number within range
+    public func makeRandom(min: Int = 0, max: Int = Int.max) -> Int {
         let top = max - min + 1
         #if os(Linux)
             // will always be initialized


### PR DESCRIPTION
Super useful method for me when generating random numbers for RGB colour values. As I haven't found a better way, I would suggest to make this public?

`makeRandom(min: 0, max: 256)`

potentially it could be called something like `randomNumber` or `randomInt`?