### PR TITLE
Cipher: add support for AES256 GCM tags

### DIFF
--- a/Sources/Crypto/Cipher/AuthenticatedCipher.swift
+++ b/Sources/Crypto/Cipher/AuthenticatedCipher.swift
@@ -12,12 +12,12 @@ import Bits
 ///
 public var AES256GCM: AuthenticatedCipher { return .init(algorithm: .aes256gcm) }
 
-public final class AuthenticatedCipher {
+public final class AuthenticatedCipher: OpenSSLStreamCipher {
     /// The `CipherAlgorithm` (e.g., AES-128 ECB) to use.
-    public let algorithm: AuthenticatedCipherAlgorithm
+    public let algorithm: OpenSSLCipherAlgorithm
 
     /// Internal OpenSSL `EVP_CIPHER_CTX` context.
-    let ctx: UnsafeMutablePointer<EVP_CIPHER_CTX>
+    public let ctx: UnsafeMutablePointer<EVP_CIPHER_CTX>
 
     /// Byte length of a GCM tag
     public static let gcmTagLength: Int = 16
@@ -92,101 +92,6 @@ public final class AuthenticatedCipher {
         try finish(into: &buffer)
 
         return buffer
-    }
-
-    /// Resets / initializes the cipher algorithm context. This must be called once before calling `update(data:)`
-    ///
-    ///     let key: Data // 16-bytes
-    ///     var aes128 = Cipher(algorithm: .aes128ecb)
-    ///     try aes128.reset(key: key, mode: .encrypt)
-    ///
-    /// - parameters:
-    ///     - key: Cipher key to use for the encryption or decryption.
-    ///            This key must be an appropriate length for the cipher you are using. See `CipherAlgorithm.keySize`.
-    ///     - iv: Optional initialization vector to use for the encryption or decryption.
-    ///           The IV must be an appropriate length for the cipher you are using. See `CipherAlgorithm.ivSize`.
-    ///     - mode: Determines whether this `Cipher` will encrypt or decrypt data.
-    ///             This is set to `CipherModel.encrypt` by default.
-    ///
-    /// - throws: `CryptoError` if reset fails, data conversion fails, or key/iv lengths are not correct.
-    public func reset(key: LosslessDataConvertible, iv: LosslessDataConvertible? = nil, mode: CipherMode = .encrypt) throws {
-        let key = key.convertToData()
-        let iv = iv?.convertToData()
-
-        let keyLength = EVP_CIPHER_key_length(algorithm.c)
-        guard keyLength == key.count else {
-            throw CryptoError(identifier: "cipherKeySize", reason: "Invalid cipher key length \(key.count) != \(keyLength).")
-        }
-
-        let ivLength = EVP_CIPHER_iv_length(algorithm.c)
-        guard (ivLength == 0 && (iv == nil || iv?.count == 0)) || (iv != nil && iv?.count == Int(ivLength)) else {
-            throw CryptoError(identifier: "cipherIVSize", reason: "Invalid cipher IV length \(iv?.count ?? 0) != \(ivLength).")
-        }
-
-        guard key.withByteBuffer({ keyBuffer in
-            iv.withByteBuffer { ivBuffer in
-                EVP_CipherInit_ex(ctx, algorithm.c, nil, keyBuffer.baseAddress!, ivBuffer?.baseAddress, mode.rawValue)
-            }
-        }) == 1 else {
-            throw CryptoError.openssl(identifier: "EVP_CipherInit_ex", reason: "Failed initializing cipher context.")
-        }
-    }
-
-    /// Encrypts or decrypts a chunk of data into the supplied buffer.
-    ///
-    ///     let key: Data // 16-bytes
-    ///     let aes128 = Cipher(algorithm: .aes128ecb)
-    ///     try aes128.reset(key: key, mode: .encrypt)
-    ///     var buffer = Data()
-    ///     try aes128.update(data: "hello", into: &buffer)
-    ///     try aes128.update(data: "world", into: &buffer)
-    ///     print(buffer) // Partial ciphertext
-    ///
-    /// Note: You _must_ call `reset()` once before calling this method.
-    ///
-    /// - parameters:
-    ///     - data: Message chunk to encrypt or decrypt.
-    ///     - buffer: Mutable buffer to append newly encrypted or decrypted data to.
-    /// - throws: `CryptoError` if update fails or data conversion fails.
-    public func update(data: LosslessDataConvertible, into buffer: inout Data) throws {
-        let input = data.convertToData()
-        var chunk = Data(count: input.count + Int(algorithm.blockSize) - 1)
-        var chunkLength: Int32 = 0
-
-        guard chunk.withMutableByteBuffer({ chunkBuffer in
-            input.withByteBuffer { inputBuffer in
-                EVP_CipherUpdate(ctx, chunkBuffer.baseAddress!, &chunkLength, inputBuffer.baseAddress!, Int32(truncatingIfNeeded: inputBuffer.count))
-            }
-        }) == 1 else {
-            throw CryptoError.openssl(identifier: "EVP_CipherUpdate", reason: "Failed updating cipher.")
-        }
-        buffer += chunk.prefix(upTo: Int(chunkLength))
-    }
-
-    /// Finalizes the encryption or decryption, appending any additional data into the supplied buffer.
-    ///
-    ///     let key: Data // 16-bytes
-    ///     let aes128 = Cipher(algorithm: .aes128ecb)
-    ///     try aes128.reset(key: key, mode: .encrypt)
-    ///     var buffer = Data()
-    ///     try aes128.update(data: "hello", into: &buffer)
-    ///     try aes128.update(data: "world", into: &buffer)
-    ///     try aes128.finish(into: &buffer)
-    ///     print(buffer) // Completed ciphertext
-    ///
-    /// Note: You _must_ call `reset()` once and `update()` at least once before calling this method.
-    ///
-    /// - parameters:
-    ///     - buffer: Mutable buffer to append any remaining encrypted or decrypted data to.
-    /// - throws: `CryptoError` if finalization fails.
-    public func finish(into buffer: inout Data) throws {
-        var chunk = Data(count: Int(algorithm.blockSize))
-        var chunkLength: Int32 = 0
-
-        guard chunk.withMutableByteBuffer({ EVP_CipherFinal_ex(ctx, $0.baseAddress!, &chunkLength) }) == 1 else {
-            throw CryptoError.openssl(identifier: "EVP_CipherFinal_ex", reason: "Failed finishing cipher.")
-        }
-        buffer += chunk.prefix(upTo: Int(chunkLength))
     }
 
     /// Gets the GCM Tag from the CIPHER_CTX struct. Only usable with a GCM-mode cipher.

--- a/Sources/Crypto/Cipher/AuthenticatedCipher.swift
+++ b/Sources/Crypto/Cipher/AuthenticatedCipher.swift
@@ -15,8 +15,10 @@ public var AES256GCM: AuthenticatedCipher { return .init(algorithm: .aes256gcm) 
 /// Max Tag Length. Used for defining the size of input and output tags.
 ///     Redefined from OpenSSL's EVP_AEAD_MAX_TAG_LENGTH, which seems to be improperly defined on some platforms.
 ///     You can find the original #define here: https://github.com/libressl/libressl/blob/master/src/crypto/evp/evp.h#L1237-L1239
-public let AEAD_MAX_TAG_LENGTH: Int32 = 16
+let AEAD_MAX_TAG_LENGTH: Int32 = 16
 
+/// AuthenticatedCipher supports AEAD-type ciphers. It feels a lot like 'Cipher' except that it supports the
+/// AEAD tag and related validation.
 public final class AuthenticatedCipher: OpenSSLStreamCipher {
     /// The `AuthenticatedCipherAlgorithm` (e.g., AES-256-GCM) to use.
     public let algorithm: OpenSSLCipherAlgorithm
@@ -99,7 +101,7 @@ public final class AuthenticatedCipher: OpenSSLStreamCipher {
 
     /// Gets the Tag from the CIPHER_CTX struct.
     ///
-    /// Note: This _must_ be called after `finish()` to retrieve the generated tag.
+    /// - note: This _must_ be called after `finish()` to retrieve the generated tag.
     ///
     /// - throws: `CryptoError` if tag retrieval fails
     public func getTag() throws -> Data {
@@ -114,7 +116,7 @@ public final class AuthenticatedCipher: OpenSSLStreamCipher {
 
     /// Sets the Tag in the CIPHER_CTX struct.
     ///
-    /// Note: This _must_ be called before `finish()` to set the tag.
+    /// - note: This _must_ be called before `finish()` to set the tag.
     ///
     /// - throws: `CryptoError` if tag set fails
     public func setTag(_ tag: LosslessDataConvertible) throws {

--- a/Sources/Crypto/Cipher/AuthenticatedCipher.swift
+++ b/Sources/Crypto/Cipher/AuthenticatedCipher.swift
@@ -195,9 +195,9 @@ public final class AuthenticatedCipher {
     ///
     /// - throws: `CryptoError` if tag retrieval fails
     public func gcmTag() throws -> Data {
-        var buffer = Data(count: Cipher.gcmTagLength)
+        var buffer = Data(count: AuthenticatedCipher.gcmTagLength)
 
-        guard buffer.withMutableByteBuffer({ EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, Int32(Cipher.gcmTagLength), $0.baseAddress!) }) == 1 else {
+        guard buffer.withMutableByteBuffer({ EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, Int32(AuthenticatedCipher.gcmTagLength), $0.baseAddress!) }) == 1 else {
             throw CryptoError.openssl(identifier: "EVP_CIPHER_CTX_ctrl", reason: "Failed getting tag (EVP_CTRL_CCM_GET_TAG).")
         }
 
@@ -212,7 +212,7 @@ public final class AuthenticatedCipher {
     public func gcmTag(_ tag: Data) throws {
         var buffer = tag
 
-        guard buffer.withMutableByteBuffer({ EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, Int32(Cipher.gcmTagLength), $0.baseAddress!) }) == 1 else {
+        guard buffer.withMutableByteBuffer({ EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, Int32(AuthenticatedCipher.gcmTagLength), $0.baseAddress!) }) == 1 else {
             throw CryptoError.openssl(identifier: "EVP_CIPHER_CTX_ctrl", reason: "Failed setting tag (EVP_CTRL_GCM_SET_TAG).")
         }
     }

--- a/Sources/Crypto/Cipher/AuthenticatedCipherAlgorithm.swift
+++ b/Sources/Crypto/Cipher/AuthenticatedCipherAlgorithm.swift
@@ -1,21 +1,21 @@
 import CNIOOpenSSL
 
-/// Specifies an authenticated cipher algorithm (e.g., AES128-ECB) to be used with a `Cipher`.
+/// Specifies an authenticated cipher algorithm (e.g., AES-256-GCM) to be used with an `AuthenticatedCipher`.
 ///
-/// Common cipher algorithms are provided as static properties on this class.
+/// Common authenticated cipher algorithms are provided as static properties on this class.
 ///
-/// There are also static methods for creating `CipherAlgorithm` such as `CipherAlgorithm.named(_:)`
+/// There are also static methods for creating `AuthenticatedCipherAlgorithm` such as `AuthenticatedCipherAlgorithm.named(_:)`
 public final class AuthenticatedCipherAlgorithm: OpenSSLCipherAlgorithm {
     // MARK: Static
 
-    /// Looks up a cipher function algorithm by name (e.g., "aes-128-cbc").
+    /// Looks up an authenticated cipher function algorithm by name (e.g., "aes-256-gcm").
     /// Uses OpenSSL's `EVP_get_cipherbyname` function.
     ///
-    ///     let algorithm = try CipherAlgorithm.named("aes-128-cbc")
+    ///     let algorithm = try CipherAlgorithm.named("aes-256-gcm")
     ///
     /// - parameters:
     ///     - name: Cipher function name
-    /// - returns: Found `CipherAlgorithm`
+    /// - returns: Found `AuthenticatedCipherAlgorithm`
     /// - throws: `CryptoError` if no cipher for that name is found.
     public static func named(_ name: String) throws -> AuthenticatedCipherAlgorithm {
         guard let cipher = EVP_get_cipherbyname(name) else {

--- a/Sources/Crypto/Cipher/AuthenticatedCipherAlgorithm.swift
+++ b/Sources/Crypto/Cipher/AuthenticatedCipherAlgorithm.swift
@@ -1,11 +1,11 @@
 import CNIOOpenSSL
 
-/// Specifies a cipher algorithm (e.g., AES128-ECB) to be used with a `Cipher`.
+/// Specifies an authenticated cipher algorithm (e.g., AES128-ECB) to be used with a `Cipher`.
 ///
 /// Common cipher algorithms are provided as static properties on this class.
 ///
 /// There are also static methods for creating `CipherAlgorithm` such as `CipherAlgorithm.named(_:)`
-public final class CipherAlgorithm {
+public final class AuthenticatedCipherAlgorithm {
     // MARK: Static
 
     /// Looks up a cipher function algorithm by name (e.g., "aes-128-cbc").
@@ -17,28 +17,16 @@ public final class CipherAlgorithm {
     ///     - name: Cipher function name
     /// - returns: Found `CipherAlgorithm`
     /// - throws: `CryptoError` if no cipher for that name is found.
-    public static func named(_ name: String) throws -> CipherAlgorithm {
+    public static func named(_ name: String) throws -> AuthenticatedCipherAlgorithm {
         guard let cipher = EVP_get_cipherbyname(name) else {
             throw CryptoError.openssl(identifier: "EVP_get_cipherbyname", reason: "No cipher named \(name) was found.")
         }
         return .init(c: cipher)
     }
 
-    /// AES-128 ECB cipher. Deprecated (see https://github.com/vapor/crypto/issues/59).
-    @available(*, deprecated, message: "Stream encryption in ECB mode is unsafe (see https://github.com/vapor/crypto/issues/59). Use AES256 in GCM mode instead.")
-    public static let aes128ecb: CipherAlgorithm = .init(c: EVP_aes_128_ecb())
-
-    /// AES-256 ECB cipher. Deprecated (see https://github.com/vapor/crypto/issues/59).
-    @available(*, deprecated, message: "Stream encryption in ECB mode is unsafe (see https://github.com/vapor/crypto/issues/59). Use AES256 in GCM mode instead.")
-    public static let aes256ecb: CipherAlgorithm = .init(c: EVP_aes_256_ecb())
-
-    /// AES-256 CBC cipher.
-    /// Only use this if you know what you are doing; use AES-256 GCM otherwise (see https://github.com/vapor/crypto/issues/59).
-    public static let aes256cbc: CipherAlgorithm = .init(c: EVP_aes_256_cbc())
-
-    /// AES-256 CFB cipher. May not be available on all platforms.
-    /// Only use this if you know what you are doing; use AES-256 GCM otherwise (see https://github.com/vapor/crypto/issues/59).
-    public static let aes256cfb: CipherAlgorithm = .init(c: EVP_aes_256_cfb128())
+    /// AES-256 GCM cipher. This is the recommended cipher.
+    /// See the global `AES256GCM` constant on usage.
+    public static let aes256gcm: AuthenticatedCipherAlgorithm = .init(c: EVP_aes_256_gcm())
 
     /// OpenSSL `EVP_CIPHER` context.
     public let c: UnsafePointer<EVP_CIPHER>

--- a/Sources/Crypto/Cipher/AuthenticatedCipherAlgorithm.swift
+++ b/Sources/Crypto/Cipher/AuthenticatedCipherAlgorithm.swift
@@ -5,7 +5,7 @@ import CNIOOpenSSL
 /// Common cipher algorithms are provided as static properties on this class.
 ///
 /// There are also static methods for creating `CipherAlgorithm` such as `CipherAlgorithm.named(_:)`
-public final class AuthenticatedCipherAlgorithm {
+public final class AuthenticatedCipherAlgorithm: OpenSSLCipherAlgorithm {
     // MARK: Static
 
     /// Looks up a cipher function algorithm by name (e.g., "aes-128-cbc").
@@ -34,27 +34,5 @@ public final class AuthenticatedCipherAlgorithm {
     /// Internal init accepting a `EVP_CIPHER`.
     public init(c: UnsafePointer<EVP_CIPHER>) {
         self.c = c
-    }
-
-    // MARK: Instance
-
-    /// Returns the OpenSSL NID type for this algorithm.
-    public var type: Int32 {
-        return EVP_CIPHER_type(c)
-    }
-
-    /// This cipher's required key length.
-    public var keySize: Int32 {
-        return EVP_CIPHER_key_length(c)
-    }
-
-    /// This cipher's required initialization vector length.
-    public var ivSize: Int32 {
-        return EVP_CIPHER_iv_length(c)
-    }
-
-    /// This cipher's block size, used internally to allocate "out" buffers.
-    public var blockSize: Int32 {
-        return EVP_CIPHER_block_size(c)
     }
 }

--- a/Sources/Crypto/Cipher/Cipher.swift
+++ b/Sources/Crypto/Cipher/Cipher.swift
@@ -48,12 +48,12 @@ public var AES256CBC: Cipher { return .init(algorithm: .aes256cbc) }
 /// Read more about [encryption on Wikipedia](https://en.wikipedia.org/wiki/Encryption).
 ///
 /// Read more about OpenSSL's [EVP encryption methods](https://www.openssl.org/docs/man1.1.0/crypto/EVP_EncryptInit.html).
-public final class Cipher {
+public final class Cipher: OpenSSLStreamCipher {
     /// The `CipherAlgorithm` (e.g., AES-128 ECB) to use.
-    public let algorithm: CipherAlgorithm
+    public let algorithm: OpenSSLCipherAlgorithm
 
     /// Internal OpenSSL `EVP_CIPHER_CTX` context.
-    let ctx: UnsafeMutablePointer<EVP_CIPHER_CTX>
+    public let ctx: UnsafeMutablePointer<EVP_CIPHER_CTX>
 
     /// Creates a new `Cipher` using the supplied `CipherAlgorithm`.
     ///
@@ -120,131 +120,9 @@ public final class Cipher {
         return buffer
     }
 
-    /// Resets / initializes the cipher algorithm context. This must be called once before calling `update(data:)`
-    ///
-    ///     let key: Data // 16-bytes
-    ///     var aes128 = Cipher(algorithm: .aes128ecb)
-    ///     try aes128.reset(key: key, mode: .encrypt)
-    ///
-    /// - parameters:
-    ///     - key: Cipher key to use for the encryption or decryption.
-    ///            This key must be an appropriate length for the cipher you are using. See `CipherAlgorithm.keySize`.
-    ///     - iv: Optional initialization vector to use for the encryption or decryption.
-    ///           The IV must be an appropriate length for the cipher you are using. See `CipherAlgorithm.ivSize`.
-    ///     - mode: Determines whether this `Cipher` will encrypt or decrypt data.
-    ///             This is set to `CipherModel.encrypt` by default.
-    ///
-    /// - throws: `CryptoError` if reset fails, data conversion fails, or key/iv lengths are not correct.
-    public func reset(key: LosslessDataConvertible, iv: LosslessDataConvertible? = nil, mode: CipherMode = .encrypt) throws {
-        let key = key.convertToData()
-        let iv = iv?.convertToData()
-
-        let keyLength = EVP_CIPHER_key_length(algorithm.c)
-        guard keyLength == key.count else {
-            throw CryptoError(identifier: "cipherKeySize", reason: "Invalid cipher key length \(key.count) != \(keyLength).")
-        }
-        
-        let ivLength = EVP_CIPHER_iv_length(algorithm.c)
-        guard (ivLength == 0 && (iv == nil || iv?.count == 0)) || (iv != nil && iv?.count == Int(ivLength)) else {
-            throw CryptoError(identifier: "cipherIVSize", reason: "Invalid cipher IV length \(iv?.count ?? 0) != \(ivLength).")
-        }
-
-        guard key.withByteBuffer({ keyBuffer in
-            iv.withByteBuffer { ivBuffer in
-                EVP_CipherInit_ex(ctx, algorithm.c, nil, keyBuffer.baseAddress!, ivBuffer?.baseAddress, mode.rawValue)
-            }
-        }) == 1 else {
-            throw CryptoError.openssl(identifier: "EVP_CipherInit_ex", reason: "Failed initializing cipher context.")
-        }
-    }
-
-    /// Encrypts or decrypts a chunk of data into the supplied buffer.
-    ///
-    ///     let key: Data // 16-bytes
-    ///     let aes128 = Cipher(algorithm: .aes128ecb)
-    ///     try aes128.reset(key: key, mode: .encrypt)
-    ///     var buffer = Data()
-    ///     try aes128.update(data: "hello", into: &buffer)
-    ///     try aes128.update(data: "world", into: &buffer)
-    ///     print(buffer) // Partial ciphertext
-    ///
-    /// Note: You _must_ call `reset()` once before calling this method.
-    ///
-    /// - parameters:
-    ///     - data: Message chunk to encrypt or decrypt.
-    ///     - buffer: Mutable buffer to append newly encrypted or decrypted data to.
-    /// - throws: `CryptoError` if update fails or data conversion fails.
-    public func update(data: LosslessDataConvertible, into buffer: inout Data) throws {
-        let input = data.convertToData()
-        var chunk = Data(count: input.count + Int(algorithm.blockSize) - 1)
-        var chunkLength: Int32 = 0
-
-        guard chunk.withMutableByteBuffer({ chunkBuffer in
-            input.withByteBuffer { inputBuffer in
-                EVP_CipherUpdate(ctx, chunkBuffer.baseAddress!, &chunkLength, inputBuffer.baseAddress!, Int32(truncatingIfNeeded: inputBuffer.count))
-            }
-        }) == 1 else {
-            throw CryptoError.openssl(identifier: "EVP_CipherUpdate", reason: "Failed updating cipher.")
-        }
-        buffer += chunk.prefix(upTo: Int(chunkLength))
-    }
-
-    /// Finalizes the encryption or decryption, appending any additional data into the supplied buffer.
-    ///
-    ///     let key: Data // 16-bytes
-    ///     let aes128 = Cipher(algorithm: .aes128ecb)
-    ///     try aes128.reset(key: key, mode: .encrypt)
-    ///     var buffer = Data()
-    ///     try aes128.update(data: "hello", into: &buffer)
-    ///     try aes128.update(data: "world", into: &buffer)
-    ///     try aes128.finish(into: &buffer)
-    ///     print(buffer) // Completed ciphertext
-    ///
-    /// Note: You _must_ call `reset()` once and `update()` at least once before calling this method.
-    ///
-    /// - parameters:
-    ///     - buffer: Mutable buffer to append any remaining encrypted or decrypted data to.
-    /// - throws: `CryptoError` if finalization fails.
-    public func finish(into buffer: inout Data) throws {
-        var chunk = Data(count: Int(algorithm.blockSize))
-        var chunkLength: Int32 = 0
-        
-        guard chunk.withMutableByteBuffer({ EVP_CipherFinal_ex(ctx, $0.baseAddress!, &chunkLength) }) == 1 else {
-            throw CryptoError.openssl(identifier: "EVP_CipherFinal_ex", reason: "Failed finishing cipher.")
-        }
-        buffer += chunk.prefix(upTo: Int(chunkLength))
-    }
-
     /// Cleans up and frees the allocated OpenSSL cipher context.
     deinit {
         EVP_CIPHER_CTX_cleanup(ctx)
         EVP_CIPHER_CTX_free(ctx)
     }
-
-}
-
-/// Available cipher modes. Either `encrypt` or `decrypt`.
-///
-/// Used when calling `reset` on a `Cipher`.
-public enum CipherMode: Int32 {
-    /// Encrypts arbitrary data to encrypted ciphertext.
-    case encrypt = 1
-
-    /// Decrypts encrypted ciphertext back to its original value.
-    case decrypt = 0
-}
-
-/// Wrapper to allow for safely working with a potentially-nil Data's byte buffer.
-extension Optional where Wrapped == Data {
-    func withByteBuffer<T>(_ closure: (BytesBufferPointer?) throws -> T) rethrows -> T {
-        switch self {
-            case .some(let data):
-                return try data.withByteBuffer({ try closure($0) })
-            case .none:
-                return try closure(nil)
-        }
-    }
-    
-    // Note: It's iffy to try this with a mutable buffer, so an Optional version
-    // of withMutableByteBuffer is not provided.
 }

--- a/Sources/Crypto/Cipher/CipherAlgorithm.swift
+++ b/Sources/Crypto/Cipher/CipherAlgorithm.swift
@@ -5,7 +5,7 @@ import CNIOOpenSSL
 /// Common cipher algorithms are provided as static properties on this class.
 ///
 /// There are also static methods for creating `CipherAlgorithm` such as `CipherAlgorithm.named(_:)`
-public final class CipherAlgorithm {
+public final class CipherAlgorithm: OpenSSLCipherAlgorithm {
     // MARK: Static
 
     /// Looks up a cipher function algorithm by name (e.g., "aes-128-cbc").
@@ -46,27 +46,5 @@ public final class CipherAlgorithm {
     /// Internal init accepting a `EVP_CIPHER`.
     public init(c: UnsafePointer<EVP_CIPHER>) {
         self.c = c
-    }
-
-    // MARK: Instance
-
-    /// Returns the OpenSSL NID type for this algorithm.
-    public var type: Int32 {
-        return EVP_CIPHER_type(c)
-    }
-
-    /// This cipher's required key length.
-    public var keySize: Int32 {
-        return EVP_CIPHER_key_length(c)
-    }
-
-    /// This cipher's required initialization vector length.
-    public var ivSize: Int32 {
-        return EVP_CIPHER_iv_length(c)
-    }
-
-    /// This cipher's block size, used internally to allocate "out" buffers.
-    public var blockSize: Int32 {
-        return EVP_CIPHER_block_size(c)
     }
 }

--- a/Sources/Crypto/Cipher/OpenSSLCipherAlgorithm.swift
+++ b/Sources/Crypto/Cipher/OpenSSLCipherAlgorithm.swift
@@ -3,34 +3,44 @@ import CNIOOpenSSL
 /// OpenSSLCipherAlgorithm represents a common set of properties shared by
 /// OpenSSL cipher algorithms.
 public protocol OpenSSLCipherAlgorithm {
-    var c: UnsafePointer<EVP_CIPHER> { get }
+    /// An initializer accepting the EVP_CIPHER to work with
     init(c: UnsafePointer<EVP_CIPHER>)
 
+    /// OpenSSL `EVP_CIPHER` context.
+    var c: UnsafePointer<EVP_CIPHER> { get }
+
+    /// Returns the OpenSSL NID type for this algorithm.
     var type: Int32 { get }
+
+    /// This cipher's required key length.
     var keySize: Int32 { get }
+
+    /// This cipher's required initialization vector length.
     var ivSize: Int32 { get }
+
+    /// This cipher's block size, used internally to allocate "out" buffers.
     var blockSize: Int32 { get }
 }
 
 /// An extension providing a default implementation for standard
 /// OpenSSL EVP versions of this protocol
 extension OpenSSLCipherAlgorithm {
-    /// Returns the OpenSSL NID type for this algorithm.
+    /// See `OpenSSLCipherAlgorithm`
     public var type: Int32 {
         return EVP_CIPHER_type(c)
     }
 
-    /// This cipher's required key length.
+    /// See `OpenSSLCipherAlgorithm`
     public var keySize: Int32 {
         return EVP_CIPHER_key_length(c)
     }
 
-    /// This cipher's required initialization vector length.
+    /// See `OpenSSLCipherAlgorithm`
     public var ivSize: Int32 {
         return EVP_CIPHER_iv_length(c)
     }
 
-    /// This cipher's block size, used internally to allocate "out" buffers.
+    /// See `OpenSSLCipherAlgorithm`
     public var blockSize: Int32 {
         return EVP_CIPHER_block_size(c)
     }

--- a/Sources/Crypto/Cipher/OpenSSLCipherAlgorithm.swift
+++ b/Sources/Crypto/Cipher/OpenSSLCipherAlgorithm.swift
@@ -1,0 +1,28 @@
+import CNIOOpenSSL
+
+public protocol OpenSSLCipherAlgorithm {
+    var c: UnsafePointer<EVP_CIPHER> { get }
+    init(c: UnsafePointer<EVP_CIPHER>)
+}
+
+extension OpenSSLCipherAlgorithm {
+    /// Returns the OpenSSL NID type for this algorithm.
+    public var type: Int32 {
+        return EVP_CIPHER_type(c)
+    }
+
+    /// This cipher's required key length.
+    public var keySize: Int32 {
+        return EVP_CIPHER_key_length(c)
+    }
+
+    /// This cipher's required initialization vector length.
+    public var ivSize: Int32 {
+        return EVP_CIPHER_iv_length(c)
+    }
+
+    /// This cipher's block size, used internally to allocate "out" buffers.
+    public var blockSize: Int32 {
+        return EVP_CIPHER_block_size(c)
+    }
+}

--- a/Sources/Crypto/Cipher/OpenSSLCipherAlgorithm.swift
+++ b/Sources/Crypto/Cipher/OpenSSLCipherAlgorithm.swift
@@ -1,10 +1,19 @@
 import CNIOOpenSSL
 
+/// OpenSSLCipherAlgorithm represents a common set of properties shared by
+/// OpenSSL cipher algorithms.
 public protocol OpenSSLCipherAlgorithm {
     var c: UnsafePointer<EVP_CIPHER> { get }
     init(c: UnsafePointer<EVP_CIPHER>)
+
+    var type: Int32 { get }
+    var keySize: Int32 { get }
+    var ivSize: Int32 { get }
+    var blockSize: Int32 { get }
 }
 
+/// An extension providing a default implementation for standard
+/// OpenSSL EVP versions of this protocol
 extension OpenSSLCipherAlgorithm {
     /// Returns the OpenSSL NID type for this algorithm.
     public var type: Int32 {

--- a/Sources/Crypto/Cipher/OpenSSLStreamCipher.swift
+++ b/Sources/Crypto/Cipher/OpenSSLStreamCipher.swift
@@ -15,7 +15,7 @@ public enum CipherMode: Int32 {
 
 /// Wrapper to allow for safely working with a potentially-nil Data's byte buffer.
 extension Optional where Wrapped == Data {
-    // Note: It's iffy to try this with a mutable buffer, so an Optional version
+    // - note: It's iffy to try this with a mutable buffer, so an Optional version
     // of withMutableByteBuffer is not provided.
     func withByteBuffer<T>(_ closure: (BytesBufferPointer?) throws -> T) rethrows -> T {
         switch self {
@@ -29,11 +29,22 @@ extension Optional where Wrapped == Data {
 
 /// OpenSSLStreamCipher is a protocol representing a higher-level interface for managing various OpenSSL stream ciphers.
 public protocol OpenSSLStreamCipher {
+    /// Resets / initializes the cipher algorithm context. Must be called before calling update.
+    /// See the default implementation extension on this protocol for more.
     func reset(key: LosslessDataConvertible, iv: LosslessDataConvertible?, mode: CipherMode) throws
+
+    /// Encrypts or decrypts a chunk of data into the supplied buffer.
+    /// See the default implementation extension on this protocol for more.
     func update(data: LosslessDataConvertible, into buffer: inout Data) throws
+
+    /// Finalizes the encryption or decryption, appending any additional data into the supplied buffer.
+    /// See the default implementation extension on this protocol for more.
     func finish(into buffer: inout Data) throws
 
+    /// The OpenSSLCipherAlgorithm this stream cipher is interacting with
     var algorithm: OpenSSLCipherAlgorithm { get }
+
+    /// The OpenSSL Cipher Stream Context
     var ctx: UnsafeMutablePointer<EVP_CIPHER_CTX> { get }
 }
 

--- a/Sources/Crypto/Cipher/OpenSSLStreamCipher.swift
+++ b/Sources/Crypto/Cipher/OpenSSLStreamCipher.swift
@@ -1,0 +1,135 @@
+import CNIOOpenSSL
+import Foundation
+import Bits
+
+/// Available cipher modes. Either `encrypt` or `decrypt`.
+///
+/// Used when calling `reset` on a `Cipher`.
+public enum CipherMode: Int32 {
+    /// Encrypts arbitrary data to encrypted ciphertext.
+    case encrypt = 1
+
+    /// Decrypts encrypted ciphertext back to its original value.
+    case decrypt = 0
+}
+
+/// Wrapper to allow for safely working with a potentially-nil Data's byte buffer.
+extension Optional where Wrapped == Data {
+    func withByteBuffer<T>(_ closure: (BytesBufferPointer?) throws -> T) rethrows -> T {
+        switch self {
+        case .some(let data):
+            return try data.withByteBuffer({ try closure($0) })
+        case .none:
+            return try closure(nil)
+        }
+    }
+
+    // Note: It's iffy to try this with a mutable buffer, so an Optional version
+    // of withMutableByteBuffer is not provided.
+}
+
+public protocol OpenSSLStreamCipher {
+    func reset(key: LosslessDataConvertible, iv: LosslessDataConvertible?, mode: CipherMode) throws
+    func update(data: LosslessDataConvertible, into buffer: inout Data) throws
+    func finish(into buffer: inout Data) throws
+
+    var algorithm: OpenSSLCipherAlgorithm { get }
+    var ctx: UnsafeMutablePointer<EVP_CIPHER_CTX> { get }
+}
+
+extension OpenSSLStreamCipher {
+    /// Resets / initializes the cipher algorithm context. This must be called once before calling `update(data:)`
+    ///
+    ///     let key: Data // 16-bytes
+    ///     var aes128 = Cipher(algorithm: .aes128ecb)
+    ///     try aes128.reset(key: key, mode: .encrypt)
+    ///
+    /// - parameters:
+    ///     - key: Cipher key to use for the encryption or decryption.
+    ///            This key must be an appropriate length for the cipher you are using. See `CipherAlgorithm.keySize`.
+    ///     - iv: Optional initialization vector to use for the encryption or decryption.
+    ///           The IV must be an appropriate length for the cipher you are using. See `CipherAlgorithm.ivSize`.
+    ///     - mode: Determines whether this `Cipher` will encrypt or decrypt data.
+    ///             This is set to `CipherModel.encrypt` by default.
+    ///
+    /// - throws: `CryptoError` if reset fails, data conversion fails, or key/iv lengths are not correct.
+    public func reset(key: LosslessDataConvertible, iv: LosslessDataConvertible? = nil, mode: CipherMode = .encrypt) throws {
+        let key = key.convertToData()
+        let iv = iv?.convertToData()
+
+        let keyLength = EVP_CIPHER_key_length(algorithm.c)
+        guard keyLength == key.count else {
+            throw CryptoError(identifier: "cipherKeySize", reason: "Invalid cipher key length \(key.count) != \(keyLength).")
+        }
+
+        let ivLength = EVP_CIPHER_iv_length(algorithm.c)
+        guard (ivLength == 0 && (iv == nil || iv?.count == 0)) || (iv != nil && iv?.count == Int(ivLength)) else {
+            throw CryptoError(identifier: "cipherIVSize", reason: "Invalid cipher IV length \(iv?.count ?? 0) != \(ivLength).")
+        }
+
+        guard key.withByteBuffer({ keyBuffer in
+            iv.withByteBuffer { ivBuffer in
+                EVP_CipherInit_ex(ctx, algorithm.c, nil, keyBuffer.baseAddress!, ivBuffer?.baseAddress, mode.rawValue)
+            }
+        }) == 1 else {
+            throw CryptoError.openssl(identifier: "EVP_CipherInit_ex", reason: "Failed initializing cipher context.")
+        }
+    }
+
+    /// Encrypts or decrypts a chunk of data into the supplied buffer.
+    ///
+    ///     let key: Data // 16-bytes
+    ///     let aes128 = Cipher(algorithm: .aes128ecb)
+    ///     try aes128.reset(key: key, mode: .encrypt)
+    ///     var buffer = Data()
+    ///     try aes128.update(data: "hello", into: &buffer)
+    ///     try aes128.update(data: "world", into: &buffer)
+    ///     print(buffer) // Partial ciphertext
+    ///
+    /// Note: You _must_ call `reset()` once before calling this method.
+    ///
+    /// - parameters:
+    ///     - data: Message chunk to encrypt or decrypt.
+    ///     - buffer: Mutable buffer to append newly encrypted or decrypted data to.
+    /// - throws: `CryptoError` if update fails or data conversion fails.
+    public func update(data: LosslessDataConvertible, into buffer: inout Data) throws {
+        let input = data.convertToData()
+        var chunk = Data(count: input.count + Int(algorithm.blockSize) - 1)
+        var chunkLength: Int32 = 0
+
+        guard chunk.withMutableByteBuffer({ chunkBuffer in
+            input.withByteBuffer { inputBuffer in
+                EVP_CipherUpdate(ctx, chunkBuffer.baseAddress!, &chunkLength, inputBuffer.baseAddress!, Int32(truncatingIfNeeded: inputBuffer.count))
+            }
+        }) == 1 else {
+            throw CryptoError.openssl(identifier: "EVP_CipherUpdate", reason: "Failed updating cipher.")
+        }
+        buffer += chunk.prefix(upTo: Int(chunkLength))
+    }
+
+    /// Finalizes the encryption or decryption, appending any additional data into the supplied buffer.
+    ///
+    ///     let key: Data // 16-bytes
+    ///     let aes128 = Cipher(algorithm: .aes128ecb)
+    ///     try aes128.reset(key: key, mode: .encrypt)
+    ///     var buffer = Data()
+    ///     try aes128.update(data: "hello", into: &buffer)
+    ///     try aes128.update(data: "world", into: &buffer)
+    ///     try aes128.finish(into: &buffer)
+    ///     print(buffer) // Completed ciphertext
+    ///
+    /// Note: You _must_ call `reset()` once and `update()` at least once before calling this method.
+    ///
+    /// - parameters:
+    ///     - buffer: Mutable buffer to append any remaining encrypted or decrypted data to.
+    /// - throws: `CryptoError` if finalization fails.
+    public func finish(into buffer: inout Data) throws {
+        var chunk = Data(count: Int(algorithm.blockSize))
+        var chunkLength: Int32 = 0
+
+        guard chunk.withMutableByteBuffer({ EVP_CipherFinal_ex(ctx, $0.baseAddress!, &chunkLength) }) == 1 else {
+            throw CryptoError.openssl(identifier: "EVP_CipherFinal_ex", reason: "Failed finishing cipher.")
+        }
+        buffer += chunk.prefix(upTo: Int(chunkLength))
+    }
+}

--- a/Sources/Crypto/Cipher/OpenSSLStreamCipher.swift
+++ b/Sources/Crypto/Cipher/OpenSSLStreamCipher.swift
@@ -15,6 +15,8 @@ public enum CipherMode: Int32 {
 
 /// Wrapper to allow for safely working with a potentially-nil Data's byte buffer.
 extension Optional where Wrapped == Data {
+    // Note: It's iffy to try this with a mutable buffer, so an Optional version
+    // of withMutableByteBuffer is not provided.
     func withByteBuffer<T>(_ closure: (BytesBufferPointer?) throws -> T) rethrows -> T {
         switch self {
         case .some(let data):
@@ -23,11 +25,9 @@ extension Optional where Wrapped == Data {
             return try closure(nil)
         }
     }
-
-    // Note: It's iffy to try this with a mutable buffer, so an Optional version
-    // of withMutableByteBuffer is not provided.
 }
 
+/// OpenSSLStreamCipher is a protocol representing a higher-level interface for managing various OpenSSL stream ciphers.
 public protocol OpenSSLStreamCipher {
     func reset(key: LosslessDataConvertible, iv: LosslessDataConvertible?, mode: CipherMode) throws
     func update(data: LosslessDataConvertible, into buffer: inout Data) throws

--- a/Tests/CryptoTests/CipherTests.swift
+++ b/Tests/CryptoTests/CipherTests.swift
@@ -42,6 +42,26 @@ class CipherTests: XCTestCase {
         try XCTAssertEqual(AES256.decrypt(ciphertext, key: key).convert(), message)
     }
 
+    func testAES256GCM() throws {
+        let message = "vapor"
+        let key = "passwordpasswordpasswordpassword"
+        let iv = "123456789012"
+        let (ciphertext, tag) = try AES256GCM.encrypt(message, key: key, iv: iv)
+        XCTAssertEqual(ciphertext.hexEncodedString(), "4fa166802c")
+        try XCTAssertEqual(AES256GCM.decrypt(ciphertext, key: key, iv: iv, tag: tag).convert(), message)
+    }
+
+    func testAES256GCMAuthenticationFailure() throws {
+        let message = "vapor"
+        let key = "passwordpasswordpasswordpassword"
+        let iv = "123456789012"
+        let (ciphertext, tag) = try AES256GCM.encrypt(message, key: key, iv: iv)
+        XCTAssertEqual(ciphertext.hexEncodedString(), "4fa166802c")
+
+        let badTag = tag.base64EncodedData()
+        XCTAssertThrowsError(try AES256GCM.decrypt(ciphertext, key: key, iv: iv, tag: badTag))
+    }
+
     func testAES128Manual() throws {
         let key = "passwordpassword"
         let aes128 = Cipher(algorithm: .aes128ecb)
@@ -59,6 +79,8 @@ class CipherTests: XCTestCase {
         ("testAES128WellKnownDecode", testAES128WellKnownDecode),
         ("testCipherReuse", testCipherReuse),
         ("testAES256Basic", testAES256Basic),
+        ("testAES256GCM", testAES256GCM),
+        ("testAES256GCMAuthenticationFailure", testAES256GCMAuthenticationFailure),
         ("testAES128Manual", testAES128Manual),
     ]
 }


### PR DESCRIPTION
Related to the discussion on https://github.com/vapor/crypto/issues/68, this adds support for retrieving tags from an AES256GCM cipher, and passing them in to decrypt.

Note: Because GCM is technically a different interface, and because of the discussion on #68, I duplicated the relevant parts of Cipher and CipherAlgorithm into AuthenticatedCipher and AuthenticatedCipherAlgorithm.

While this results in some duplicated code (as noted on #68), the resulting interface is indeed much nicer - especially since you'll get a compile-time error if you mix and match unauthenticated and authenticated ciphers.

To help reduce some of the code duplication, we also created a pair of protocols - OpenSSLCipherAlgorithm and OpenSSLStreamCipher - that capture some of the needed common behavior, and deduplicates the code via protocol extensions.

Fixes https://github.com/vapor/crypto/issues/68