### PR TITLE
Moved LosslessDataConvertible definitions over from vapor/core

### DIFF
--- a/Sources/Crypto/BCrypt/BCryptDigest.swift
+++ b/Sources/Crypto/BCrypt/BCryptDigest.swift
@@ -171,7 +171,7 @@ public final class BCryptDigest {
     /// - returns: Base 64 encoded plaintext
     private func base64Encode(_ dataConvertible: LosslessDataConvertible) throws -> String {
         let data = dataConvertible.convertToData()
-        let dataBytes = [UInt8](data)
+        let dataBytes = [UInt8](data)! // guaranteed non-nil
 
         let encodedBytes = UnsafeMutablePointer<Int8>.allocate(capacity: 25)
         defer { encodedBytes.deallocate() }

--- a/Sources/Crypto/MAC/OTP.swift
+++ b/Sources/Crypto/MAC/OTP.swift
@@ -139,7 +139,7 @@ private func generateOTP(secret: LosslessDataConvertible, algorithm: DigestAlgor
     // get last 4 bits of hash for use as offset
     let offset = Int(digest[digest.count - 1] & 0x0f)
     // get 4 bytes of the hash using offset
-    let subdigest = Data(digest[offset...offset + 3])
+    let subdigest = Data(digest[offset...offset + 3])! // Identity initializer
     // convert data to UInt32
     var num = subdigest.withUnsafeBytes { $0.baseAddress!.assumingMemoryBound(to: UInt32.self).pointee.bigEndian }
     // remove most sig bit

--- a/Sources/Random/LosslessDataConvertible.swift
+++ b/Sources/Random/LosslessDataConvertible.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+/// A type that can be created from `Data` in a lossless, unambiguous way.
+public protocol LosslessDataConvertible {
+    /// Losslessly converts `Data` to this type.
+    init?(_ data: Data)
+}
+
+/// A type that can be converted to `Data`
+public protocol CustomDataConvertible {
+    /// Losslessly converts this type to `Data`.
+    func convertToData() -> Data
+}
+
+extension Data {
+    /// Converts this `Data` to a `LosslessDataConvertible` type.
+    ///
+    ///     let string = Data([0x68, 0x69]).convert(to: String.self)
+    ///     print(string) // "hi"
+    ///
+    /// - parameters:
+    ///     - type: The `LosslessDataConvertible` to convert to.
+    /// - returns: Instance of the `LosslessDataConvertible` type.
+    public func convert<T>(to type: T.Type = T.self) -> T? where T: LosslessDataConvertible {
+        return T.init(self)
+    }
+}
+
+extension String: LosslessDataConvertible, CustomDataConvertible {
+    /// Converts this `String` to data using `.utf8`.
+    public func convertToData() -> Data {
+        return Data(utf8)
+    }
+    
+    /// Converts `Data` to a `utf8` encoded String.
+    ///
+    /// - returns: nil if `data` isn't `utf8` encoded.
+    public init?(_ data: Data) {
+        guard let string = String(data: data, encoding: .utf8) else {
+            /// FIXME: string convert _from_ data is not actually lossless.
+            /// this should really only conform to a `LosslessDataRepresentable` protocol.
+            return nil
+        }
+        self = string
+    }
+}
+
+extension Array: LosslessDataConvertible, CustomDataConvertible where Element == UInt8 {
+    /// Converts this `[UInt8]` to `Data`.
+    public func convertToData() -> Data {
+        return Data(bytes: self)
+    }
+    
+    /// Converts `Data` to `[UInt8]`.
+    public init?(_ data: Data) {
+        self = .init(data)
+    }
+}
+
+extension Data: LosslessDataConvertible, CustomDataConvertible {
+    /// `LosslessDataConvertible` conformance.
+    public func convertToData() -> Data {
+        return self
+    }
+    
+    /// `LosslessDataConvertible` conformance.
+    public init?(_ data: Data) {
+        self = data
+    }
+}


### PR DESCRIPTION
Trying to keep the style of `LosslessDataConvertible` consistent with `LosslessStringConvertible`