### PR TITLE
remove NIOOpenSSL in favor of CCryptoOpenSSL

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,9 +10,6 @@ let package = Package(
     dependencies: [
         // 🌎 Utility package containing tools for byte manipulation, Codable, OS APIs, and debugging.
         .package(url: "https://github.com/vapor/core.git", from: "3.0.0"),
-
-        /// Bindings to OpenSSL-compatible libraries for TLS support in SwiftNIO
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "1.0.0"),
         
         /// Links OpenSSL / LibreSSL to SPM.
         .package(url: "https://github.com/apple/swift-nio-ssl-support.git", from: "1.0.0"),
@@ -30,7 +27,6 @@ let package = Package(
             "Core",
             "COperatingSystem",
             "Debugging",
-            "NIOOpenSSL",
             "Random"
         ]),
         .testTarget(name: "CryptoTests", dependencies: ["Crypto"]),

--- a/Sources/Crypto/Cipher/AuthenticatedCipher.swift
+++ b/Sources/Crypto/Cipher/AuthenticatedCipher.swift
@@ -1,4 +1,4 @@
-import CNIOOpenSSL
+import CCryptoOpenSSL
 import Foundation
 import Bits
 

--- a/Sources/Crypto/Cipher/AuthenticatedCipherAlgorithm.swift
+++ b/Sources/Crypto/Cipher/AuthenticatedCipherAlgorithm.swift
@@ -1,4 +1,4 @@
-import CNIOOpenSSL
+import CCryptoOpenSSL
 
 /// Specifies an authenticated cipher algorithm (e.g., AES-256-GCM) to be used with an `AuthenticatedCipher`.
 ///

--- a/Sources/Crypto/Cipher/OpenSSLCipherAlgorithm.swift
+++ b/Sources/Crypto/Cipher/OpenSSLCipherAlgorithm.swift
@@ -1,4 +1,4 @@
-import CNIOOpenSSL
+import CCryptoOpenSSL
 
 /// OpenSSLCipherAlgorithm represents a common set of properties shared by
 /// OpenSSL cipher algorithms.

--- a/Sources/Crypto/Cipher/OpenSSLStreamCipher.swift
+++ b/Sources/Crypto/Cipher/OpenSSLStreamCipher.swift
@@ -1,4 +1,4 @@
-import CNIOOpenSSL
+import CCryptoOpenSSL
 import Foundation
 import Bits
 

--- a/Sources/Crypto/RSA/RSAKey.swift
+++ b/Sources/Crypto/RSA/RSAKey.swift
@@ -1,5 +1,4 @@
 import CCryptoOpenSSL
-import NIOOpenSSL
 import Foundation
 
 /// Represents an in-memory RSA key.

--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - run:
           name: Clone Vapor
-          command: git clone -b master https://github.com/vapor/vapor.git
+          command: git clone -b 3 https://github.com/vapor/vapor.git
           working_directory: ~/
       - run:
           name: Switch Vapor to this Crypto revision
@@ -77,7 +77,7 @@ jobs:
     steps:
       - run:
           name: Clone PostgreSQL
-          command: git clone -b master https://github.com/vapor/postgresql.git
+          command: git clone -b 1 https://github.com/vapor/postgresql.git
           working_directory: ~/
       - run:
           name: Switch PostgreSQL to this Crypto revision


### PR DESCRIPTION
vapor/crypto moved to using `CCryptoOpenSSL` for access to OpenSSL APIs in #75. However, some remnants were left over. This PR removes them and the `swift-nio-ssl` dependency altogether. 

Note: `swift-nio-ssl-support` package remains since `.systemLibrary` is not supported in Swift 4.1 which this package targets.