### PR TITLE
HKDF implementation

### DIFF
--- a/Sources/OpenCrypto/KDF.swift
+++ b/Sources/OpenCrypto/KDF.swift
@@ -1,0 +1,50 @@
+//
+//  KDF.swift
+//
+//
+//  Created by Craz1k0ek on 12/06/2020.
+//
+
+import Foundation
+
+/// Cryptographic key derivation.
+///
+/// https://en.wikipedia.org/wiki/Key_derivation_function
+public enum KDF {
+    
+    /// Derives a symmetric encryption key from the secret using HKDF key derivation.
+    /// - Parameters:
+    ///   - hashFunction: The hash function to use for key derivation.
+    ///   - ikm: The input key material.
+    ///   - salt: The salt to use for key derivation.
+    ///   - info: The shared information to use for key derivation.
+    ///   - outputByteCount: The length in bytes of resulting symmetric key.
+    /// - Returns: The derived symmetric key.
+    ///
+    /// https://en.wikipedia.org/wiki/HKDF
+    public static func hkdf<H>(using hashFunction: H, secret ikm: Data, salt: Data? = nil, sharedInfo: Data = Data(), outputByteCount: Int) -> SymmetricKey where H: HashFunction {
+        let salt = salt == nil ? Data(repeating: 0, count: H.Digest.byteCount) : salt!
+        
+        // Generate the PRK (extract).
+        let pseudoRandomKey = HMAC<H>.authenticationCode(for: ikm, using: SymmetricKey(data: salt))
+        
+        // Prepare the OKM.
+        var mixin = Data()
+        var outputKeyMaterial = Data()
+        
+        // Perform the derivation (expand).
+        for iteration in 0 ..< Int(ceil(Double(outputByteCount) / Double(H.Digest.byteCount))) {
+            var preMixin = Data()
+            preMixin.append(mixin)
+            preMixin.append(sharedInfo)
+            preMixin.append(Data([1 + UInt8(iteration)]))
+            
+            mixin = Data(HMAC<H>.authenticationCode(for: preMixin, using: SymmetricKey(data: pseudoRandomKey)))
+            
+            outputKeyMaterial += mixin
+        }
+        
+        return SymmetricKey(data: outputKeyMaterial[0 ..< outputByteCount])
+    }
+    
+}

--- a/Tests/OpenCryptoTests/KDFTests.swift
+++ b/Tests/OpenCryptoTests/KDFTests.swift
@@ -1,0 +1,88 @@
+//
+//  KDFTests.swift
+//
+//
+//  Created by Craz1k0ek on 12/06/2020.
+//
+
+import XCTest
+import OpenCrypto
+
+class KDFTests: XCTestCase {
+    // Tests ran from https://tools.ietf.org/html/rfc5869#appendix-A
+    
+    func testBasicSHA256() throws {
+        let ikm = Data(base64Encoded: "CwsLCwsLCwsLCwsLCwsLCwsLCwsLCw==")!
+        let salt = Data(base64Encoded: "AAECAwQFBgcICQoLDA==")!
+        let info = Data(base64Encoded: "8PHy8/T19vf4+Q==")!
+        let outputCount = 42
+        let expectedOkm = SymmetricKey(data: Data(base64Encoded: "PLJfJfqs1XqQQ09k0DYvKi0tCpDPGlpMXbAtVuzExb80AHII1biHGFhl")!)
+        
+        let okm = KDF.hkdf(using: SHA256(), secret: ikm, salt: salt, sharedInfo: info, outputByteCount: outputCount)
+        print(expectedOkm)
+        print(okm)
+        XCTAssertEqual(okm, expectedOkm)
+    }
+    
+    func testLongerSHA256() throws {
+        let ikm = Data(base64Encoded: "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk8=")!
+        let salt = Data(base64Encoded: "YGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq8=")!
+        let info = Data(base64Encoded: "sLGys7S1tre4ubq7vL2+v8DBwsPExcbHyMnKy8zNzs/Q0dLT1NXW19jZ2tvc3d7f4OHi4+Tl5ufo6err7O3u7/Dx8vP09fb3+Pn6+/z9/v8=")!
+        let outputCount = 82
+        let expectedOkm = SymmetricKey(data: Data(base64Encoded: "sR45jcgDJ6HI5/eMWWpJNE8BLtotTvrYoFDMTBmvqXxZBFqZyseCcnHLQcZeWQ4J2jJ1YAwvCbg2d5OprKPbccwwxYF57D6HwUwB1cHzQ08dhw==")!)
+        
+        let okm = KDF.hkdf(using: SHA256(), secret: ikm, salt: salt, sharedInfo: info, outputByteCount: outputCount)
+        print(expectedOkm)
+        print(okm)
+        XCTAssertEqual(okm, expectedOkm)
+    }
+    
+    func testZeroSaltInfoSHA256() throws {
+        let ikm = Data(base64Encoded: "CwsLCwsLCwsLCwsLCwsLCwsLCwsLCw==")!
+        let outputCount = 42
+        
+        let expectedOkm = SymmetricKey(data: Data(base64Encoded: "jaTndaVjwY9xX4AqBjxaMbihH1xe4Yeew0VOXzxzjS2dIBOV+qS2GpbI")!)
+        
+        let okm = KDF.hkdf(using: SHA256(), secret: ikm, outputByteCount: outputCount)
+        print(expectedOkm)
+        print(okm)
+        XCTAssertEqual(okm, expectedOkm)
+    }
+    
+    func testBasicSHA1() throws {
+        let ikm = Data(base64Encoded: "CwsLCwsLCwsLCws=")!
+        let salt = Data(base64Encoded: "AAECAwQFBgcICQoLDA==")!
+        let info = Data(base64Encoded: "8PHy8/T19vf4+Q==")!
+        let outputCount = 42
+        let expectedOkm = SymmetricKey(data: Data(base64Encoded: "CFoB6hsQ82kzBotW76WtgaTxS4IvWwkVaKnN1PFV/aLCLkIkeNMF8/iW")!)
+        
+        let okm = KDF.hkdf(using: Insecure.SHA1(), secret: ikm, salt: salt, sharedInfo: info, outputByteCount: outputCount)
+        print(expectedOkm)
+        print(okm)
+        XCTAssertEqual(okm, expectedOkm)
+    }
+    
+    func testLongerSHA1() throws {
+        let ikm = Data(base64Encoded: "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk8=")!
+        let salt = Data(base64Encoded: "YGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq8=")!
+        let info = Data(base64Encoded: "sLGys7S1tre4ubq7vL2+v8DBwsPExcbHyMnKy8zNzs/Q0dLT1NXW19jZ2tvc3d7f4OHi4+Tl5ufo6err7O3u7/Dx8vP09fb3+Pn6+/z9/v8=")!
+        let outputCount = 82
+        let expectedOkm = SymmetricKey(data: Data(base64Encoded: "C9dwp00RYPfJ8SzVkSoG6/9q3K6JnZIZH+QwVnO6L/6Po/Gk5a158/M0s7ICshc8SG6jfOPTl+0DTH+d/rFcXpJzNtBEH0xDAOLP8NCQC1LTtA==")!)
+        
+        let okm = KDF.hkdf(using: Insecure.SHA1(), secret: ikm, salt: salt, sharedInfo: info, outputByteCount: outputCount)
+        print(expectedOkm)
+        print(okm)
+        XCTAssertEqual(okm, expectedOkm)
+    }
+    
+    func testZeroSaltInfoSHA1() throws {
+        let ikm = Data(base64Encoded: "CwsLCwsLCwsLCwsLCwsLCwsLCwsLCw==")!
+        let outputCount = 42
+        let expectedOkm = SymmetricKey(data: Data(base64Encoded: "CsGvcAKz12HR5VKY2p0FBrmuUgVyIKMG4Htrh+jfIdDqAAM94DmE00kY")!)
+        
+        let okm = KDF.hkdf(using: Insecure.SHA1(), secret: ikm, outputByteCount: outputCount)
+        print(expectedOkm)
+        print(okm)
+        XCTAssertEqual(okm, expectedOkm)
+    }
+}


### PR DESCRIPTION
+ Added a KDF enum to support key derivation.
+ Implemented HKDF using the existing crypto resources.
+ Added HKDF tests in the new KDFTests file using the RFC test vectors.